### PR TITLE
Ensure that MHA input args are contiguous

### DIFF
--- a/keys_values/model.py
+++ b/keys_values/model.py
@@ -695,6 +695,11 @@ class CausalSelfAttention(nn.Module):
             k = torch.cat((k_roped, k[..., rope_n_elem:]), dim=-1)
 
         # Inner part of multi-head self-attention computation
+        # SDPA kernels need contiguous tensors to work most efficiently, or
+        # even to work at all
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
         if self.kv_cache is None:
             # Default causal self-attention
             y, _ = mha(


### PR DESCRIPTION
If `q`, `k`, `v` inputs to MHA are not contiguous, this is not efficient, and may even fail for some SDPA kernels.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
