### PR TITLE
KV cache checkpoint objects are now reused across several `GradientAc…

### DIFF
--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -1023,7 +1023,16 @@ def wrap_gpt_model(
                 + add_msg,
                 fabric,
             )
-        # track_unmatched_annotations = lambda layer_idx, chunk_idx: layer_idx in (0, 35)  # DEBUG
+        if grad.layercp_pin_memory:
+            print_message(
+                "CPU pages for activation (layer input) checkpointing are pinned",
+                fabric,
+            )
+        if grad.cachecp_pin_memory:
+            print_message(
+                "CPU pages for KV cache checkpointing are pinned",
+                fabric,
+            )
         model = LongContextGradientModel(
             **common_kwargs,
             layers_per_cell=grad.layers_per_cell,
@@ -1033,12 +1042,13 @@ def wrap_gpt_model(
             cache_kwargs=cache_kwargs,
             train_cache_kwargs=train_cache_kwargs,
             backward_tmp_array_limit_gb=backward_tmp_array_limit_gb,
+            layercp_pin_memory=grad.layercp_pin_memory,
+            cachecp_pin_memory=grad.cachecp_pin_memory,
             autograd_hooks_kwargs=autograd_hooks_kwargs,
             profile_steps=profile_grad_times,
             offload_device=cpu_offload_device,
             offload_grad_accum=offload_grad_accum,
             layer_checkpoint_chunk_size=layer_checkpoint_chunk_size,
-            track_unmatched_annotations=None,
             debug_profile_forward=profile_parts == "forward",
             debug_profile_backward=profile_parts == "backward",
             debug_dont_use_autograd_hooks=debug_dont_use_autograd_hooks,
@@ -1363,7 +1373,6 @@ def fit(
                 loss = model(**model_kwargs)
                 loss.backward()
 
-            # END DEBUG
             running_loss.update(loss.detach().to(device=optim_device))
             flush_io_streams()
             if size_logs is not None:

--- a/keys_values/finetune/utils.py
+++ b/keys_values/finetune/utils.py
@@ -51,7 +51,7 @@ from keys_values.utils import flush_io_streams
 def debug_print_param_names(model: GPT):
     rows = ["", "Names of model (GPT)", ""]
     rows.extend([name for name, _ in model.named_parameters()])
-    for i, block in enumerate(model.transformer.h):
+    for i, block in enumerate(model._get_layer_blocks()):
         rows.extend(["", f"Names of block {i} (Block)", ""])
         rows.extend([name for name, _ in block.named_parameters()])
     for pname, block in [

--- a/keys_values/kvcache/gradient/accumulate.py
+++ b/keys_values/kvcache/gradient/accumulate.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import Counter
 import contextlib
 from functools import partial
 from itertools import accumulate
@@ -23,7 +24,11 @@ from keys_values.config import Config
 from keys_values.attention import do_softcapping
 from keys_values.gpu_memory import RecordGPUMemory
 from keys_values.head_model import HeadModel
-from keys_values.kvcache.base import KVCacheReplayLog, DefaultKVCache
+from keys_values.kvcache.base import (
+    KVCacheReplayLog,
+    DefaultKVCache,
+    KVCacheParams,
+)
 from keys_values.kvcache.basics import KVCacheWithBuffers
 from keys_values.kvcache.buffers import (
     KVCacheBuffersParams,
@@ -76,7 +81,7 @@ def copy_requires_grad(x: torch.Tensor) -> torch.Tensor:
 
 class GradientAccumulator:
     """
-    Implements gradient accumulation for a row of cells, using activation
+    Implements gradient accumulation for shards of a model, using activation
     checkpointing.
 
     The initial forward pass in inference mode must have been run already,
@@ -86,13 +91,22 @@ class GradientAccumulator:
 
     * Forward inference pass to compute KV cache buffer checkpoints of type
       :class:`KVCacheBufferCheckpoints`. This is done using inference replay
-      caches created by :func:`inference_replay_cache_factory`.
+      caches created by :func:`inference_replay_cache_factory`. The KV cache
+      checkpoints are allocated in :meth:`run_head_model` and used for all
+      subsequent :meth:`run` calls.
     * Forward-backward computations over columns, from right to left, using
       :class:`CellComputation`. These use head gradients on top, produce head
       gradients on the right, and apart from accumulating the model gradients
       also compute head gradients for the row below. If `autograd_hooks` is
       given and of type :class:`CellComputationAutogradHooks`, the largest
       tensors are dealt with in a special way, saving most of the memory.
+
+    Layers of the model are grouped into shards, each call of :meth:`run` is
+    for one shard. `cache_lengths` is a list of tuples, one for each shard.
+    The tuple contains the `cache_length` for each layer in the shard. This
+    information allows to create a sufficient number of KV cache checkpointers.
+    `cache_params` are KV cache parameters used for creating the checkpointers.
+    Here, `cache_params.cache_length` is ignored.
 
     If `len(chunks_per_cell) == 1`, this is a special case, where no caching is
     done along the row. This is mostly useful for testing, or if context widths
@@ -105,13 +119,15 @@ class GradientAccumulator:
     `autograd_hooks.arrays_cleanup`. This information can be used in order
     to clean things up if an out of memory error is caught. Note that if
     `autograd_hooks` is of type :class:`CellComputationAutogradHooks`, it
-    plays two different toles (see above).
+    plays two different roles (see above).
 
     """
 
     def __init__(
         self,
         config: Config,
+        cache_lengths: List[Tuple[int, ...]],
+        cache_params: KVCacheParams,
         autograd_hooks: Optional[AutogradHooks],
         qname: Optional[str] = None,
         cache_kwargs: Optional[Dict[str, Any]] = None,
@@ -128,6 +144,12 @@ class GradientAccumulator:
             )
 
         self.config = config
+        if sum(len(x) for x in cache_lengths) != config.n_layer:
+            raise ValueError(
+                f"cache_lengths = {cache_lengths}: Sum of tuple lengths must be equal to config.n_layer = {config.n_layer}"
+            )
+        self.cache_lengths = cache_lengths
+        self._cache_params = cache_params
         self.autograd_hooks = autograd_hooks
         self.verbose = verbose
         self._verbose_more = (
@@ -137,7 +159,8 @@ class GradientAccumulator:
         if cache_kwargs is None:
             cache_kwargs = dict()
         self.cache_kwargs = cache_kwargs
-        self._kv_cache_checkpoints = None  # Created when needed
+        self._kv_cache_checkpoints = None  # Assigned when needed
+        self._checkpoints_per_length = None  # Created when needed
         self._batch_size = None
         self._clear_internal()
         # Annotation usage logs
@@ -166,6 +189,9 @@ class GradientAccumulator:
         if self._kv_cache_checkpoints is not None:
             del self._kv_cache_checkpoints
             self._kv_cache_checkpoints = None
+        if self._checkpoints_per_length is not None:
+            del self._checkpoints_per_length
+            self._checkpoints_per_length = None
 
     def _initialize_internal(
         self,
@@ -206,7 +232,9 @@ class GradientAccumulator:
             elem.input_range
             for elem in get_chunks_for_cells(chunks_per_cell, chunk_lens)
         ]
-        if not self.do_checkpointing:
+        if self.do_checkpointing:
+            self._create_checkpointers()
+        else:
             # Sanity check
             assert self.inputs_ranges == [(0, self.seq_length)]
         # Ranges to be used in `run_head_model` and `run_input_embeddings`
@@ -243,15 +271,105 @@ class GradientAccumulator:
         points = list(range(0, self.seq_length, chunk_size)) + [self.seq_length]
         self.top_bottom_ranges = list(zip(points[:-1], points[1:]))
 
+    def _create_checkpointers(self):
+        """
+        Given `cache_lengths` and `chunks_per_cell`, create all KV cache
+        buffer checkpoints needed in subsequent calls of :meth:`run`. These
+        are stored in `_checkpoints_per_length`. This allows us to reuse
+        checkpoint objects in several calls of :meth:`run`, which amortizes
+        the time to allocate them.
+
+        """
+        chunk_numbers = list(accumulate(self.chunks_per_cell))[:-1]
+        buffer_params = KVCacheBuffersParams.from_params(self._cache_params)
+        if self._pin_memory:
+            pin_memory = [True] * len(chunk_numbers)
+        else:
+            pin_memory = None
+        # How many checkpointers per cache length?
+        num_required: Dict[int, int] = dict()
+        for clens in self.cache_lengths:
+            c = Counter(clens)
+            for clen, count in c.items():
+                num_required[clen] = max(num_required.get(clen, 0), count)
+        if self.qname == "default":
+            self._checkpoints_per_length = {
+                cache_length: [
+                    KVCacheBufferDefaultCheckpoints(
+                        chunk_numbers=chunk_numbers,
+                        params=buffer_params,
+                        cache_length=cache_length,
+                        batch_size=self._batch_size,
+                        pin_memory=pin_memory,
+                    )
+                    for _ in range(num)
+                ]
+                for cache_length, num in num_required.items()
+            }
+        else:
+            # Checkpoints are quantized. They can all share the same
+            # quantized buffers object.
+            dequant_kwargs = dict(
+                max_num_ranges=self.cache_kwargs.get("max_num_ranges"),
+            )
+            max_cache_length = max(
+                clen for clens in self.cache_lengths for clen in clens
+            )
+            quant_buffers = create_quantized_kv_buffers(
+                qname=self.qname,
+                cache_lengths=[max_cache_length],
+                cache_params=self._cache_params,
+                cache_kwargs=self.cache_kwargs,
+                dequant_kwargs=dequant_kwargs,
+            )[0]
+            self._checkpoints_per_length = {
+                cache_length: [
+                    KVCacheBufferQuantizedCheckpoints(
+                        chunk_numbers=chunk_numbers,
+                        quant_buffers=quant_buffers,
+                        cache_length=cache_length,
+                        pin_memory=pin_memory,
+                    )
+                    for _ in range(num)
+                ]
+                for cache_length, num in num_required.items()
+            }
+
+    def _select_checkpointers(
+        self,
+        cache_lengths_of_shard: List[int],
+    ) -> List[KVCacheBufferCheckpoints]:
+        """
+        Given cache lengths of layers in shard, select KV cache checkpoints
+        from `_checkpoints_per_length`.
+
+        """
+        num_used: Dict[int, int] = dict()
+        result = []
+        for cache_length in cache_lengths_of_shard:
+            pos = num_used.get(cache_length, 0)
+            cps = self._checkpoints_per_length[cache_length]
+            if pos >= len(cps):
+                raise IndexError(
+                    f"cache_length = {cache_length}: _checkpoints_per_length has {len(cps)} entries, but need more.\n"
+                    f"GradientAccumulator has been created with cache_lengths = {self.cache_lengths}.\n"
+                    "If you created LongContextGradientModel with a certain "
+                    "`gpt_model` and `layers_per_cell`, this fixes the shards "
+                    "for which `run` can be called. Did you call it with a "
+                    "different shard?"
+                )
+            result.append(cps[pos])
+            num_used[cache_length] = pos + 1
+        return result
+
     def _create_checkpoints_and_buffers(
         self,
         model_part: CellBlocks,
-    ) -> Tuple[List[DefaultKVCacheBuffers], List[Optional[KVCacheBufferCheckpoints]]]:
+    ) -> Tuple[List[DefaultKVCacheBuffers], List[KVCacheBufferCheckpoints]]:
         """
-        Creates buffers for inference replay caches and checkpointing objects, the
-        latter only if checkpointing is used. Note that respective buffers are stored
-        on the same device as the block of a layer is on. This makes sure things work
-        in a model-parallel context as well.
+        Creates buffers for inference replay caches and checkpointing objects.
+        The latter are selected from `_checkpoints_per_length`, using
+        :meth:`_select_checkpointers`.
 
         """
         assert self.do_checkpointing
@@ -261,13 +379,9 @@ class GradientAccumulator:
         # :class:`DefaultKVCacheBuffers`, which do not quantize. Quantization is
         # only done when storing and retrieving the checkpoints.
         cache_buffers = []
-        buffer_params = None
-        cache_params = None
+        buffer_params = KVCacheBuffersParams.from_params(self._cache_params)
         cache_lengths = []
         for _, kv_cache in model_part.get_kv_caches():
-            if buffer_params is None:
-                cache_params = kv_cache.get_params()
-                buffer_params = KVCacheBuffersParams.from_params(cache_params)
             cache_length = kv_cache.cache_length
             cache_buffers.append(
                 DefaultKVCacheBuffers(
@@ -276,47 +390,9 @@ class GradientAccumulator:
                 )
             )
             cache_lengths.append(cache_length)
-        # Checkpointing objects, which may include quantizers and dequantization
-        # buffers
-        chunk_numbers = list(accumulate(self.chunks_per_cell))[:-1]
-        if self._pin_memory:
-            pin_memory = [True] * len(chunk_numbers)
-        else:
-            pin_memory = None
-        if self.qname == "default":
-            checkpoints = [
-                KVCacheBufferDefaultCheckpoints(
-                    chunk_numbers=chunk_numbers,
-                    params=buffer_params,
-                    cache_length=cache_length,
-                    batch_size=self._batch_size,
-                    pin_memory=pin_memory,
-                )
-                for cache_length in cache_lengths
-            ]
-        else:
-            # Checkpoints are quantized
-            dequant_kwargs = dict(
-                max_num_ranges=self.cache_kwargs.get("max_num_ranges"),
-            )
-            max_cache_length = max(cache_lengths)
-            quant_buffers = create_quantized_kv_buffers(
-                qname=self.qname,
-                cache_lengths=[max_cache_length],
-                cache_params=cache_params,
-                cache_kwargs=self.cache_kwargs,
-                dequant_kwargs=dequant_kwargs,
-                first_block_idx=model_part.first_layer_idx,
-            )[0]
-            checkpoints = [
-                KVCacheBufferQuantizedCheckpoints(
-                    chunk_numbers=chunk_numbers,
-                    quant_buffers=quant_buffers,
-                    cache_length=cache_length,
-                    pin_memory=pin_memory,
-                )
-                for cache_length in cache_lengths
-            ]
+        # Checkpoint objects are selected from a pool
+        print("cache_lengths: " + str(cache_lengths))  # DEBUG
+        checkpoints = self._select_checkpointers(cache_lengths)
 
         return cache_buffers, checkpoints
 
@@ -358,14 +434,14 @@ class GradientAccumulator:
 
     def _deallocate_buffers(self, ir_caches: List[KVCacheWithBuffers]):
         if self.do_checkpointing:
-            # Deallocate GPU buffers for checkpoints
-            for checkpoint in self._kv_cache_checkpoints:
-                if isinstance(checkpoint, KVCacheBufferQuantizedCheckpoints):
-                    checkpoint.quant_buffers.deallocate()
             # Deallocate GPU buffers for inference replay caches
             deallocate_kv_cache_buffers(ir_caches)
             for cache in ir_caches:
                 cache.set_checkpoint_hook(None)
+            # Note: GPU buffers used by KV cache checkpoints must not be
+            # deallocated, as they are reused over several calls of
+            # :meth:`run`.
+            self._kv_cache_checkpoints = None
 
     def _hooks_for_cell_computation(self) -> Optional[CellComputationAutogradHooks]:
         if self.autograd_hooks is not None and isinstance(
@@ -435,6 +511,10 @@ class GradientAccumulator:
                 infer_replay_caches,
                 get_inputs_slice,
             )
+            if torch.cuda.is_available():
+                # Synchronize here to make sure the checkpoints are properly
+                # written to CPU (host), before they are read below
+                torch.cuda.synchronize()
             # We could delete `infer_replay_caches` here. But we still use their
             # buffers to de-quantize checkpoints below
         else:
@@ -735,6 +815,10 @@ class GradientAccumulator:
         Note that `get_inputs_slice` and `write_outputs_slice` can refer to the
         same underlying buffer or checkpoint object. We guarantee that any slice
         is read before it is written to.
+
+        Note: `gpt_model` passed here only needs to contain the blocks
+        `gpt_model.transformer.ln_f` and `gpt_model.lm_head` related to the
+        head model. This is the case if it is a shard only.
 
         Args:
             gpt_model: GPT model (or just a shard, see

--- a/keys_values/kvcache/gradient/main.py
+++ b/keys_values/kvcache/gradient/main.py
@@ -717,11 +717,22 @@ class LongContextGradientModel(LongContextInferenceModel):
             self.autograd_hooks = CleanupArraysAutogradHooks(arrays_cleanup)
         else:
             self.autograd_hooks = None
+        # Determine cache length of layers in each shard
+        all_cache_lengths = [
+            cache.cache_length for cache in self.gpt_model.get_kv_caches()
+        ]
+        cache_lengths = [
+            tuple(all_cache_lengths[i] for i in range(start, end))
+            for start, end in self._get_shard_ranges()
+        ]
+        cache_params = self.gpt_model.get_kv_cache_params(0)
         # Accumulator object
         # Key and value buffers should not be annotated for the first chunk if
         # there is only a single chunk in the first cell
         self.accumulator = GradientAccumulator(
             config=self.config,
+            cache_lengths=cache_lengths,
+            cache_params=cache_params,
             autograd_hooks=self.autograd_hooks,
             qname=self.cachecp_qname,
             cache_kwargs=dict(
@@ -778,7 +789,7 @@ class LongContextGradientModel(LongContextInferenceModel):
                 lines.append(f"cache_length    = {cache_length}")
             else:
                 cl_str = ", ".join(f"{i}:{j}" for i, j in cache_lengths)
-                lines.append("cache_length    = " + cl_str)
+                lines.append("cache_lengths   = " + cl_str)
             lines.extend(
                 [
                     f"chunk_sizes     = {self.chunk_sizes}",
@@ -958,6 +969,12 @@ class LongContextGradientModel(LongContextInferenceModel):
                 )
                 print("\n".join(lines))
 
+    def _get_shard_ranges(self) -> List[Tuple[int, int]]:
+        # Note that `layer_checkpoints.layer_numbers[-1] == n_layer + 1` is used
+        # for storing head gradients
+        layer_numbers = self.layer_checkpoints.layer_numbers[:-1]
+        return reversed(list(zip(layer_numbers[:-1], layer_numbers[1:])))
+
     def _backward_accumulate_gradients_nocheck(self, count: int):
         """
         Main workhorse. Runs nested activation checkpointing in order to
@@ -1097,11 +1114,8 @@ class LongContextGradientModel(LongContextInferenceModel):
             self._record_gpu_memory_snapshots.stop_recording()
 
         # Loop over rows of cells, from the top down.
-        # Note that `layer_checkpoints.layer_numbers[-1] == n_layer + 1` is used
-        # for storing head gradients
-        layer_numbers = self.layer_checkpoints.layer_numbers[:-1]
         for first_layer_idx, end_layer_idx in wrap_tqdm_if_verbose(
-            reversed(list(zip(layer_numbers[:-1], layer_numbers[1:]))),
+            self._get_shard_ranges(),
             verbose=self.verbose is VerbosityLevels.SOME,
         ):
             if self._use_arrays_cleanup and self.autograd_hooks is not None:

--- a/keys_values/lora.py
+++ b/keys_values/lora.py
@@ -216,11 +216,11 @@ class GPT(BaseModel):
         return model_copy
 
     def check_for_nan(self, do_grads: bool = False) -> None:
-        for block in self.transformer.h:
+        for block in self._get_layer_blocks():
             block.attn.check_for_nan(do_grads)
 
     def reset_lora_parameters(self):
-        for block in self.transformer.h:
+        for block in self._get_layer_blocks():
             block.reset_lora_parameters()
 
 

--- a/keys_values/model.py
+++ b/keys_values/model.py
@@ -132,16 +132,20 @@ class GPT(nn.Module):
         # Multi-head attention (includes position encoding)
         self.mha.set_seq_length(value)
 
-    def are_kv_caches_assigned(self) -> bool:
-        status = [kv_cache is not None for kv_cache in self.get_kv_caches()]
-        result = any(status)
-        if result and not all(status):
-            raise IndexError("Some layers have KV caches assigned, but not all")
-        return result
+    def _has_layers(self) -> bool:
+        return self.transformer is not None and hasattr(self.transformer, "h")
 
     def _num_layers(self) -> int:
-        has_no_layers = self.transformer is None or not hasattr(self.transformer, "h")
-        return 0 if has_no_layers else len(self.transformer.h)
+        return len(self._get_layer_blocks())
+
+    def _get_layer_blocks(self) -> List["Block"]:
+        """
+        We use this method instead of `self.transformer.h` to ensure that
+        classes such as :class:`CellBlocks` or :class:`GPTShardOfBlocks`
+        surface other methods of this class correctly.
+
+        """
+        return [block for block in self.transformer.h] if self._has_layers() else []
 
     def assign_kv_caches(self, kv_caches: List[Optional[KVCache]]):
         """
@@ -164,7 +168,7 @@ class GPT(nn.Module):
                 self._check_kv_cache(self.config, kv_cache, batch_size, dtype)
         elif num_none != num_layers:
             raise ValueError(f"kv_caches must not contain None or all be None")
-        for kv_cache, block in zip(kv_caches, self.transformer.h):
+        for kv_cache, block in zip(kv_caches, self._get_layer_blocks()):
             if kv_cache is not None:
                 kv_cache.set_seq_length(self.max_seq_length)
             block.attn.kv_cache = kv_cache
@@ -196,7 +200,7 @@ class GPT(nn.Module):
             raise ValueError("Model has KV caches assigned already")
         if max_seq_length is None:
             max_seq_length = self.max_seq_length
-        for block in self.transformer.h:
+        for block in self._get_layer_blocks():
             attn = block.attn
             kv_cache = attn.kv_cache
             if (
@@ -216,7 +220,14 @@ class GPT(nn.Module):
         self._default_kv_cache = True
 
     def get_kv_caches(self) -> List[KVCache]:
-        return [block.attn.kv_cache for block in self.transformer.h]
+        return [block.attn.kv_cache for block in self._get_layer_blocks()]
+
+    def are_kv_caches_assigned(self) -> bool:
+        status = [kv_cache is not None for kv_cache in self.get_kv_caches()]
+        result = any(status)
+        if result and not all(status):
+            raise IndexError("Some layers have KV caches assigned, but not all")
+        return result
 
     def reset(self) -> None:
         """
@@ -357,7 +368,7 @@ class GPT(nn.Module):
         return cls(Config.from_name(name, **kwargs))
 
     def clear_kv_caches(self) -> None:
-        for block in self.transformer.h:
+        for block in self._get_layer_blocks():
             block.attn.kv_cache = None
         self._default_kv_cache = False
 
@@ -374,7 +385,7 @@ class GPT(nn.Module):
         num_layers = self._num_layers()
         if not (0 <= block_idx < num_layers):
             raise IndexError(f"block_idx={block_idx}, must be in [0, {num_layers}])")
-        kv_cache = self.transformer.h[block_idx].attn.kv_cache
+        kv_cache = self.get_kv_caches()[block_idx]
         return None if kv_cache is None else kv_cache.get_params()
 
     def kv_cache_max_forward_length(self) -> Optional[int]:
@@ -444,7 +455,7 @@ class GPT(nn.Module):
         kv_caches = []
         try:
             # Remove KV caches before copy is created
-            for l_ix, block in enumerate(self.transformer.h):
+            for l_ix, block in enumerate(self._get_layer_blocks()):
                 kv_cache = block.attn.kv_cache
                 if (
                     kv_cache is not None

--- a/keys_values/optimize/model_factory.py
+++ b/keys_values/optimize/model_factory.py
@@ -377,9 +377,6 @@ class GPTShardOfBlocks(GPTFull):
         if self._has_layers():
             self.max_seq_length = config.block_size
 
-    def _has_layers(self) -> bool:
-        return self.transformer is not None and hasattr(self.transformer, "h")
-
     @property
     def max_seq_length(self) -> int:
         if self._has_layers():

--- a/test/kvcache/test_gradient.py
+++ b/test/kvcache/test_gradient.py
@@ -256,6 +256,8 @@ def test_gradient_row_of_cells(
         debug_cache_tensors = None
     accumulator = GradientAccumulator(
         config=config,
+        cache_lengths=[tuple(cache_lengths)],
+        cache_params=params,
         autograd_hooks=autograd_hooks,
         qname=qname,
         debug_tensors=debug_cache_tensors,
@@ -309,6 +311,8 @@ def test_gradient_row_of_cells(
         debug_cache_tensors_comp = None
     accumulator_comp = GradientAccumulator(
         config=config,
+        cache_lengths=[tuple(cache_lengths)],
+        cache_params=params,
         autograd_hooks=None,
         qname="torch-quantized8",  # will not be used
         debug_tensors=debug_cache_tensors_comp,

--- a/test/kvcache/test_gradient_sharded.py
+++ b/test/kvcache/test_gradient_sharded.py
@@ -268,7 +268,7 @@ def compute_gradients_on_device(
     with torch.no_grad():
         x = gpt_model_on_device.transformer.wte(input_ids)
         layer_inputs = []
-        for block in gpt_model_on_device.transformer.h:
+        for block in gpt_model_on_device._get_layer_blocks():
             layer_inputs.append(x)
             x = block(x, input_ids, gpt_model_on_device.mha)
     head_input = copy_requires_grad(x)

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -922,8 +922,14 @@ def test_mha_is_passed_on(device):
         write_head_gradients_slice=write_head_gradients_slice,
         targets=targets,
     )
-    model_part = DefaultCellBlocks(gpt_model, 0, n_layer)
-    ir_caches = accumulator._create_inference_replay_caches(model_part)
+    # Note: Must call `accumulator._create_inference_replay_caches` for
+    # single-layer shards only
+    ir_caches = [
+        accumulator._create_inference_replay_caches(
+            DefaultCellBlocks(gpt_model, block_idx, 1)
+        )[0]
+        for block_idx in range(n_layer)
+    ]
     _compare_mhas(
         orig_caches,
         ir_caches,
@@ -931,6 +937,7 @@ def test_mha_is_passed_on(device):
     )
 
     # Training replay caches
+    model_part = DefaultCellBlocks(gpt_model, 0, n_layer)
     cell = CellComputation(
         model_part=model_part,
         autograd_hooks=None,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1683,7 +1683,7 @@ def test_sdpa_choice_kv_cache(config):
 
     reset_meth = [
         (block.attn.kv_cache, block.attn.kv_cache.mha.scaled_dot_product_attention)
-        for block in model.transformer.h
+        for block in model._get_layer_blocks()
     ]
 
     if SUPPORTS_FLASH_ATTENTION:


### PR DESCRIPTION
…cumulator.run` calls. And fixed CL args for memory pinning (#67)

Step towards decoupling checkpointing (on CPU) from GPU computation.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
