### PR TITLE
Make sure that 1D token_positions special case is exploited. Alternat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,10 +630,10 @@ library (and would be very happy for help, see
 * PyTorch `flex_attention` SDPA: We use
   `torch.nn.attention.flex_attention.flex_attention`, see
   [keys_values/flex_attention.py](./keys_values/flex_attention.py) for details.
-  These kernels are the default. We support `config.sliding_window_size` and
-  `config.attention_logit_softcapping` with them. We also reorder `key`,
-  `query` so that the new entries (corresponding to `query`) are on the right
-  end. Cannot return attention weights.
+  These kernels are the default. We support `config.attention_logit_softcapping`
+  with them, but not (currently) `config.sliding_window_size`. We also reorder
+  `key`, `query` so that the new entries (corresponding to `query`) are on the
+  right end. Cannot return attention weights.
   
 * Query-padded PyTorch SDPA: We use
   `torch.nn.functional.scaled_dot_product_attention`, but pad `query` with
@@ -677,6 +677,21 @@ Relevant arguments are:
   in naive SDPA, used in `forward` pass.
 * `attention_backward_temp_size_gb`: Same size limit, but for SDPA computations
   during the `backward` pass. This is discussed [below](#gradient-computation).
+
+**Note**: We do not currently support `config.sliding_window_size` with any of
+our fast SDPA kernels (for reasons explained below). This feature is used in
+`Gemma-2`, `Gemma-3` or `Mistral` models. You can attain much the same effect by
+using the `lastrec` KV cache policy with cache length set to the window size.
+This not only allows to use a fast SDPA kernel, but also saves time and memory
+due to a small KV cache length (strictly speaking, using the `lastrec` policy is
+equivalent to `config.sliding_window_size` only if `kv_cache.chunk_size == 1`,
+which would run slowly; `lastrec` with an economical chunk size is a reasonable
+approximation, see [here](#cache-length-and-chunk-size)).
+
+Why don't we support `config.sliding_window_size` with `flex_attention`? This
+is because for almost all KV cache policies, the cache entries become reordered.
+We can undo the reordering to support `flex_attention` with standard causal
+attention mask, but not with `config.sliding_window_size`.
 
 ### Gradient Computation
 
@@ -902,6 +917,14 @@ features generically:
   the box. If replaying your cache needs more information than stored in
   [AttnWeightsReplayLog](./keys_values/kvcache/attn_weights.py#L39), you need
   to create a subclass.
+
+**Note**: `AttnWeightsKVCache` allows the KV information for tokens to be in
+the cache for some `(b, h)`, batch dimensions and heads, but not for others.
+This means that `token_positions` is a genuine 3D index. If your score-based
+cache policy does not require this (so that KV information for a token is
+either in the cache for all `(b, h)`, or not at all), it may be better to not
+inherit from `AttnWeightsKVCache`. This is because the fact that `token_positions`
+is essentially 1D, is used to save time and memory downstreams.
 
 ### [KVCacheWithBuffers](./keys_values/kvcache/basics.py#L42)
 

--- a/keys_values/attention.py
+++ b/keys_values/attention.py
@@ -138,6 +138,9 @@ class MultiHeadSelfAttention:
         used for non-prefill (`input_pos > 0`) if `flexatt_args` is provided
         and attention weights are not required. Cannot be used if attention
         weights are required.
+        Note: Currently, `flex_attention` cannot be used if a sliding window
+        size is used. This is because our current mechanism to support
+        `token_positions` is not compatible with a sliding window size.
     - :const:`SDPA_IMPL_QPADDED_PYTORCH: Variant of PyTorch kernel, where
         `query` is zero-padded. This is implemented in
         :func:`sdpa_wrapper.scaled_dot_product_attention`. Cannot be used
@@ -184,6 +187,7 @@ class MultiHeadSelfAttention:
         use_eager_kernel: Optional[UseEagerPredicate] = None,
         filter_sdpa_kernels: bool = True,
         flexatt_args: Optional[FlexAttentionArgs] = None,
+        sort_if_3d: bool = False,
     ) -> None:
         self.config = config
         if pos_encoding is None:
@@ -201,11 +205,22 @@ class MultiHeadSelfAttention:
                 "may run out of GPU memory. Consider using a model without "
                 "attention logit softcapping or provide flexatt_args."
             )
+        if self.config.sliding_window_size is not None:
+            print(
+                "Your model uses sliding window attention "
+                "(config.sliding_window_size != None). This is not supported "
+                "at the moment with any of our efficient SDPA kernels. You can "
+                "obtain the same effect with choosing a 'lastrec' KV cache "
+                "policy, saving time, memory, and being able to use an efficient "
+                "SDPA kernel. I will continue, but this may run really quite "
+                "slowly."
+            )
         if use_eager_kernel is None and not use_eager_sdpa_always:
             # This is a good choice for `kv_len = 32768`
             use_eager_kernel = lambda kv_len, q_len: q_len < 512
         self._use_eager_kernel = use_eager_kernel
         self.flexatt_args = flexatt_args
+        self._sort_if_3d = sort_if_3d
 
     @property
     def sdpa_kernels(self) -> Union[SDPBackend, List[SDPBackend]]:
@@ -256,7 +271,7 @@ class MultiHeadSelfAttention:
                 part of the mask matrix
             annotation_callback: If this is given, it is a callback passed
                 to specialized SDPA variants. Its arguments are
-                `key, value, sort_index`.
+                `key, value, extra_info, extend_kv`.
 
         Returns:
             `attn_output, attn_weights`, where `attn_weights` is `None` if
@@ -355,7 +370,10 @@ class MultiHeadSelfAttention:
 
         """
         must_eager = return_attn_weights or self.use_eager_sdpa_always
-        use_flex_att = self.flexatt_args is not None and not must_eager
+        sws_given = sliding_window_size is not None
+        use_flex_att = (
+            self.flexatt_args is not None and not must_eager and not sws_given
+        )
         if self.config.attention_logit_softcapping is not None:
             if use_flex_att:
                 return SDPA_IMPL_FLEXATTENTION
@@ -366,11 +384,7 @@ class MultiHeadSelfAttention:
             return SDPA_IMPL_PYTORCH
         if use_flex_att:
             return SDPA_IMPL_FLEXATTENTION
-        elif (
-            must_eager
-            or sliding_window_size is not None
-            or self._use_eager_kernel(kv_len, q_len)
-        ):
+        elif must_eager or sws_given or self._use_eager_kernel(kv_len, q_len):
             return SDPA_IMPL_EAGER_BLOCKS
         else:
             return SDPA_IMPL_QPADDED_PYTORCH
@@ -419,22 +433,26 @@ class MultiHeadSelfAttention:
                 sdpa_kernels=self.sdpa_kernels,
                 do_filter_kernels=self._do_filter_kernels,
                 annotation_callback=annotation_callback,
+                sort_if_3d=self._sort_if_3d,
             )
             if self._do_filter_kernels:
                 self._do_filter_kernels = False
                 self._sdpa_kernels = filtered_kernels
         elif sdpa_mode == SDPA_IMPL_FLEXATTENTION:
+            if sliding_window_size is not None:
+                raise ValueError("Sliding window size not supported with FlexAttention")
             attn_outputs = scaled_dot_product_attention_flexatt(
                 flexatt_args=self.flexatt_args,
                 query=query,
                 key=k_and_v.keys(),
                 value=k_and_v.values(),
                 scale_factor=scale_factor,
-                sliding_window_size=sliding_window_size,
+                sliding_window_size=None,
                 attention_logit_softcapping=self.config.attention_logit_softcapping,
                 input_pos=input_pos,
                 token_positions=token_positions,
                 annotation_callback=annotation_callback,
+                sort_if_3d=self._sort_if_3d,
             )
         elif sdpa_mode == SDPA_IMPL_PYTORCH:
             # We need `key` and `value` at the same time here. For the training
@@ -443,7 +461,7 @@ class MultiHeadSelfAttention:
             if annotation_callback is not None:
                 annotation_callback = partial(
                     annotation_callback,
-                    sort_index=None,
+                    extra_info=dict(),
                 )
             attn_outputs, filtered_kernels = pytorch_scaled_dot_product_attention(
                 query=query,

--- a/keys_values/attention_utils.py
+++ b/keys_values/attention_utils.py
@@ -451,6 +451,10 @@ def sample_token_positions(
     input_pos: int,
     device: torch.device,
 ) -> torch.Tensor:
+    if input_pos < kv_len:
+        raise ValueError(f"input_pos = {input_pos}, must be >= kv_len = {kv_len}")
+    if q_len > kv_len:
+        raise ValueError(f"q_len = {q_len}, must be <=  kv_len = {kv_len}")
     index_kwargs = dict(dtype=torch.int64, device=device)
     token_positions = torch.zeros(
         (batch_size, n_query_groups, kv_len),
@@ -458,17 +462,18 @@ def sample_token_positions(
     )
     for bs in range(batch_size):
         for nq in range(n_query_groups):
-            token_positions[bs, nq, :] = torch.randperm(
+            row = torch.randperm(
                 input_pos,
                 **index_kwargs,
             )[:kv_len]
             # Ensure that `input_pos:(input_pos + q_len)` is present
             index = torch.randperm(kv_len, **index_kwargs)[:q_len]
-            token_positions[bs, nq, index] = torch.arange(
+            row[index] = torch.arange(
                 input_pos,
                 input_pos + q_len,
                 **index_kwargs,
             )
+            token_positions[bs, nq, :] = row
     return token_positions
 
 
@@ -480,7 +485,9 @@ def pytorch_scaled_dot_product_attention(
     sdpa_kernels: Union[SDPBackend, List[SDPBackend]],
     do_filter_kernels: bool = False,
     mask: Optional[torch.Tensor] = None,
-    annotation_callback: Optional[Callable[[torch.Tensor, torch.Tensor], None]] = None,
+    annotation_callback: Optional[
+        Callable[[torch.Tensor, torch.Tensor, bool], None]
+    ] = None,
 ) -> Tuple[torch.Tensor, Optional[List[SDPBackend]]]:
     """
     If you call this repeatedly and want to filter `sdpa_kernels`, use
@@ -510,6 +517,7 @@ def pytorch_scaled_dot_product_attention(
     n_head = query.shape[1]
     n_query_groups = key.shape[1]
     enable_gqa = n_query_groups < n_head
+    extend_kv = enable_gqa
     if enable_gqa:
         # Some efficient kernels have not implemented
         # `enabla_gqa=True`. It is better to extend keys, values in
@@ -517,8 +525,9 @@ def pytorch_scaled_dot_product_attention(
         key = repeat_interleave(key, n_head)
         value = repeat_interleave(value, n_head)
         enable_gqa = key.shape[1] == n_query_groups
+        extend_kv = not enable_gqa
     if annotation_callback is not None:
-        annotation_callback(key, value)
+        annotation_callback(key, value, extend_kv=extend_kv)
     kwargs = dict(
         query=query,
         key=key,

--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -465,11 +465,19 @@ class SDPAArgs:
             which different graphs are compiled. Zero-padding of the `query`
             argument is used then. If not given, each different `q_len` value
             gets its own graph (not recommended).
+        reorder_sort_if_3d: For both SDPA variants, we (currently) reorder
+            `key, value` tensors so that standard causal masking applies.
+            If `token_positions` is inherently 3D (in that
+            `token_positions[b, h, j]` depends on `b, h`), this can be done
+            by sorting for each `b, h`, or in a way that is cheaper to
+            compute, but may need a little more memory. If this argument is
+            `True`, we use sorting.
     """
 
     flex_attention: bool = True
     flex_extend_kv: bool = True
     flex_num_q_lens: Optional[int] = 4
+    reorder_sort_if_3d: bool = False
 
     def __post_init__(self):
         if self.flex_num_q_lens is not None and self.flex_num_q_lens <= 0:

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -855,6 +855,12 @@ def get_mha_and_cache_kwargs(
     yarn_rope: bool,
     fabric: Optional[L.Fabric],
 ) -> Dict[str, Any]:
+    """
+    Compiles `mha_kwargs` to be used for creating the model. We also update
+    `kv_cache.cache_kwargs` with these arguments, so that KV caches use them
+    as well.
+
+    """
     cache_kwargs = kv_cache.cache_kwargs
     # Order of preference for SDPA kernels
     limit_gb = attention_forward_temp_size_gb
@@ -876,6 +882,7 @@ def get_mha_and_cache_kwargs(
         mha_kwargs["sdpa_kernels"] = cache_kwargs["sdpa_kernels"]
     else:
         mha_kwargs["sdpa_kernels"] = SDPA_KERNELS_BEST_ORDERING
+    mha_kwargs["sort_if_3d"] = sdpa.reorder_sort_if_3d
     if sdpa.flex_attention:
         # The block mask managers (for prefill, for chunks) are shared
         # among all multi-head attention blocks
@@ -929,10 +936,7 @@ def wrap_gpt_model(
     )
     gpt_model.clear_kv_caches()
     cache_kwargs = dict() if kv_cache.cache_kwargs is None else kv_cache.cache_kwargs
-    cache_kwargs = dict(
-        cache_kwargs,
-        max_chunk_size=kv_cache.maximum_chunk_size(),
-    )
+    cache_kwargs["max_chunk_size"] = kv_cache.maximum_chunk_size()
     cache_kwargs = cleanup_cache_kwargs(
         split_name(kv_cache.name)[0],
         cache_kwargs,

--- a/keys_values/flex_attention.py
+++ b/keys_values/flex_attention.py
@@ -26,6 +26,7 @@ from keys_values.sdpa_wrapper import (
     sdpa_check_args,
     reorder_key_value,
     ReorderAnnotationCallback,
+    zeropad_query_on_left,
 )
 from keys_values.utils import repeat_interleave
 
@@ -83,7 +84,6 @@ class FlexAttnManager:
     The idea for managers is to share compiled block masks and attention
     functions across several layers and iterations, so that compilations
     are required initially only.
-
     """
 
     def __init__(self):
@@ -181,7 +181,6 @@ class FlexAttnForPrefillManager(FlexAttnManager):
 
     Note that `flex_attention` is often not used for the prefill calls, because
     standard PyTorch SDPA is faster. It is used only with non-standard SDPA.
-
     """
 
     def __init__(self):
@@ -257,6 +256,12 @@ class FlexAttnForChunkManager(FlexAttnManager):
     of compiled graphs, even if chunks with many different `q_len` sizes come
     in.
 
+    `extend_kv` field: Hack used to get around issue with FlexAttention.
+    Details: https://github.com/awslabs/keys_values/issues/34.
+    For unclear reasons, `enable_gqa=True` does not work, except for the first
+    graph to be stored in `_entries`. This is why `extend_kv=False` for the
+    first entry, `extend_kv=True` for all others. Note that the first entry
+    is the most used one in general.
     """
 
     def __init__(self, q_lens: Optional[List[int]] = None):
@@ -367,18 +372,17 @@ class FlexAttentionArgs:
     must be done by the caller.
 
     Args:
-        extend_kv: If `True` we always extend `key, value` to `n_head`. This
-            needs more memory, only use if the default does not work.
         q_lens: If given, this is a list of `q_len` chunk lengths for which
             graphs are created. Any `q_len` passed to :meth:`attn_fn` with
             `input_pos > 0` is mapped to the smallest entry `>= q_len`.
-
+        extend_kv: If `True` we always extend `key, value` to `n_head`. This
+            needs more memory, only use if the default does not work.
     """
 
     def __init__(
         self,
-        extend_kv: bool = False,
         q_lens: Optional[List[int]] = None,
+        extend_kv: bool = False,
     ):
         self.attn_prefill_manager = FlexAttnForPrefillManager()
         self.attn_chunk_manager = FlexAttnForChunkManager(q_lens)
@@ -453,6 +457,7 @@ def scaled_dot_product_attention_flexatt(
     input_pos: int,
     token_positions: Optional[torch.Tensor],
     annotation_callback: Optional[ReorderAnnotationCallback] = None,
+    sort_if_3d: bool = False,
 ) -> torch.Tensor:
     """
     Computes scaled dot product attention (SDPA) using PyTorch
@@ -488,12 +493,13 @@ def scaled_dot_product_attention_flexatt(
             given for `input_pos > 0`, it is equivalent to `arange(kv_len)`.
         annotation_callback: If this is given and `key, value` are reordered,
             the results are passed to this callback.
+        sort_if_3d: See :func:`reorder_key_value`.
 
     Returns:
         Attention outputs, shape `(batch_size, n_heads, q_len, head_size)`
 
     """
-    batch_size, n_head, n_query_groups, q_len, kv_len, _ = sdpa_check_args(
+    batch_size, n_head, n_query_groups, q_len, kv_len, head_size = sdpa_check_args(
         query,
         key,
         value,
@@ -511,9 +517,16 @@ def scaled_dot_product_attention_flexatt(
                 f"token_positions.shape = {token_positions.shape}, key.shape = {key.shape}: Not compatible"
             )
     if token_positions is not None:
-        key, value, sort_index = reorder_key_value(key, value, token_positions)
+        key, value, extra_info = reorder_key_value(
+            key,
+            value,
+            token_positions.detach(),
+            input_pos,
+            q_len,
+            sort_if_3d,
+        )
     else:
-        sort_index = None
+        extra_info = dict()
     enable_gqa = n_query_groups < n_head
     requires_grad = query.requires_grad or key.requires_grad or value.requires_grad
     attn_fn, extend_kv = flexatt_args.attn_fn(
@@ -531,24 +544,23 @@ def scaled_dot_product_attention_flexatt(
         key = repeat_interleave(key, n_head)
         value = repeat_interleave(value, n_head)
         enable_gqa = False
+        extend_kv = True
+    else:
+        extend_kv = False
     q_len_tr = flexatt_args.transform_q_len(q_len)
     if q_len_tr > q_len:
         # Use zero padding
-        shape = tuple(query.shape[:2]) + (q_len_tr - q_len, query.shape[-1])
-        query = torch.cat(
-            (
-                query,
-                torch.zeros(*shape, dtype=query.dtype, device=query.device),
-            ),
-            dim=2,
-        )
+        # Importantly, zeros are appended **on the left**, not on the right.
+        # The real query entries must be right-aligned with key, value,
+        # otherwise our causal attention masking does not work out properly.
+        # See :func:`keys_values.sdpa_wrapper.scaled_dot_product_attention`.
+        query = zeropad_query_on_left(query, q_len_tr - q_len)
     # Deal with non-standard `scale_factor`
-    head_size = query.shape[-1]
     diff = scale_factor * math.sqrt(head_size)
     if not (0.999 < diff < 1.001):
         query = query * diff
     if annotation_callback is not None:
-        annotation_callback(key, value, sort_index)
+        annotation_callback(key, value, extra_info, extend_kv)
 
     result = attn_fn(
         query=query,
@@ -558,7 +570,7 @@ def scaled_dot_product_attention_flexatt(
         enable_gqa=enable_gqa,
     )
     if q_len_tr > q_len:
-        result = result[:, :, :q_len, :]
+        result = result[:, :, (-q_len):, :].clone()
     return result
 
 

--- a/keys_values/kvcache/attn_weights.py
+++ b/keys_values/kvcache/attn_weights.py
@@ -32,7 +32,12 @@ from keys_values.kvcache.buffers import (
     positions_wrap_around,
     PositionsType,
 )
-from keys_values.utils import index_to_3d, bits_for_torch_dtype, bitsize_of
+from keys_values.utils import (
+    index_to_3d,
+    bits_for_torch_dtype,
+    bitsize_of,
+    is_index_1d,
+)
 
 
 class AttnWeightsReplayLog(DefaultKVCacheReplayLog):
@@ -174,13 +179,19 @@ class AttnWeightsReplayLog(DefaultKVCacheReplayLog):
         self,
         input_pos: int,
         num: int,
-        **kwargs,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
     ) -> torch.Tensor:
         relpos, bstart = self._position_and_offset(input_pos)
         parts = []
         block = self._slot_positions[relpos]
         blocksize = block.shape[-1]
         bend = min(bstart + num, blocksize)
+        if device is None:
+            device = torch.get_default_device()
+        if dtype is None:
+            dtype = torch.int64
+        kwargs = dict(dtype=dtype, device=device)
         parts.append(block[:, :, bstart:bend].to(**kwargs))
         done = bend - bstart
         while done < num:
@@ -210,8 +221,8 @@ def update_token_positions(
     next_grace_pos: Optional[int] = None,
 ) -> Optional[UpdateTokenPositionsGracePeriod]:
     """
-    `token_positions` of shape `(batch_size, n_query_groups, cache_length)`
-    contains token positions for each slot. If `batch_size < batch_size`,
+    `token_positions` of shape `(bs, n_query_groups, cache_length)`
+    contains token positions for each slot. If `batch_size < bs`,
     only the leading rows are used. It is updated here with new token positions
     `input_pos` to `input_pos + num - 1`.
 
@@ -223,6 +234,7 @@ def update_token_positions(
 
     """
     assert token_positions.ndim == 3
+    tp_is_1d = is_index_1d(token_positions)
     bs, n_query_groups, cache_length = token_positions.shape
     assert 1 <= batch_size <= bs
     assert num >= 1 and input_pos >= 0
@@ -231,20 +243,27 @@ def update_token_positions(
     assert cache_full or input_pos + num <= cache_length
     assert grace_period >= 0
     device = token_positions.device
-    arange_kwargs = dict(dtype=token_positions.dtype, device=device)
+    dtype = token_positions.dtype
+    arange_kwargs = dict(dtype=dtype, device=device)
     result = None
     if not cache_full:
         start = input_pos
         end = input_pos + num
-        token_positions[:batch_size, :, start:end] = torch.arange(
-            start,
-            end,
-            **arange_kwargs,
-        ).view(1, 1, -1)
+        new_tps = torch.arange(start, end, **arange_kwargs)
+        if tp_is_1d:
+            # Note: We keep `token_positions` 1D even if `batch_size < bs`
+            token_positions[0, 0, start:end] = new_tps
+        else:
+            token_positions[:batch_size, :, start:end] = new_tps.view(1, 1, -1)
     else:
         assert index is not None
         shape = (batch_size, n_query_groups, num)
         assert index.shape == shape, (index.shape, shape)
+        index_is_1d = is_index_1d(index)
+        if tp_is_1d and not index_is_1d:
+            raise ValueError(
+                "token_positions is essentially 1D, but index is not. Resize token_positions to 3D before calling this function."
+            )
         if grace_period > 0:
             assert next_grace_pos is not None
             # Grace period, and the cache buffer is already full:
@@ -262,15 +281,20 @@ def update_token_positions(
                 n_query_groups=n_query_groups,
                 device=device,
                 return_tensor=True,
+                dtype=dtype,
             )
             # Update token_pos
             new_pos = torch.arange(
                 input_pos + num1,
                 input_pos + num,
                 **arange_kwargs,
-            ).view(1, 1, -1)
+            )
             pos_flat = positions[0, 0, :]
-            token_positions[:batch_size, :, pos_flat] = new_pos
+            if tp_is_1d:
+                # Note: We keep `token_positions` 1D even if `batch_size < bs`
+                token_positions[0, 0, pos_flat] = new_pos
+            else:
+                token_positions[:batch_size, :, pos_flat] = new_pos.view(1, 1, -1)
             start_token_pos = input_pos - grace_period
             result = UpdateTokenPositionsGracePeriod(
                 positions=positions,
@@ -280,17 +304,17 @@ def update_token_positions(
         else:
             start_token_pos = input_pos
 
-        new_token_pos = index_to_3d(
-            torch.arange(start_token_pos, start_token_pos + num, **arange_kwargs),
-            batch_size,
-            n_query_groups,
-        )
-        token_positions[:batch_size, ...].scatter_(
-            -1,
-            index,
-            new_token_pos,
-        )
-        return result
+        new_tps = torch.arange(start_token_pos, start_token_pos + num, **arange_kwargs)
+        if tp_is_1d and index_is_1d:
+            # Note: We keep `token_positions` 1D even if `batch_size < bs`
+            token_positions[0, 0, index[0, 0, :]] = new_tps
+        else:
+            token_positions[:batch_size, ...].scatter_(
+                -1,
+                index,
+                index_to_3d(new_tps, batch_size, n_query_groups),
+            )
+    return result
 
 
 DEFAULT_REPLAY_LOG_BLOCKSIZE = 1024

--- a/keys_values/kvcache/base.py
+++ b/keys_values/kvcache/base.py
@@ -292,6 +292,15 @@ class KVCache(torch.nn.Module):
 
     def token_positions(self) -> torch.Tensor:
         """
+        Note: For many cache policies, a token is either represented in the
+        cache for all `(b, h)`, batch dimensions and heads, or for none.
+        This means that `token_positions` is essentially 1D. This simpler
+        structure is exploited downstream.
+        Make sure to return an index obtained as
+        `index_to_3d(tp_1d, batch_size, n_query_groups)` with
+        :func:`keys_values.utils.index_to_3d` in this case, so that the
+        simpler structure is recognized.
+
         Returns:
             Token positions in slots of the cache, shape
             `(batch_size, n_query_groups, current_length)`, where
@@ -570,13 +579,14 @@ class DefaultKVCache(KVCache):
 
         # Multi-head self-attention main computation
         return_attn_weights = (not for_prefill) and self.update_requires_attn_weights()
+        token_positions = None if for_prefill else self.token_positions()
         attn_outputs, attn_weights = self.mha(
             query=query,
             k_and_v=k_and_v,
             block_idx=self.block_idx,
             input_pos=input_pos,
             return_attn_weights=return_attn_weights,
-            token_positions=None if for_prefill else self.token_positions(),
+            token_positions=token_positions,
         )
         if attn_weights is not None and return_attn_weights:
             # Pass attention weights and query length to KV cache
@@ -771,9 +781,10 @@ class KVCacheReplayLog:
 
     def extract_index(
         self,
-        token_pos: int,
+        input_pos: int,
         num: int,
-        **kwargs,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
     ) -> torch.Tensor:
         """
                 Returns slice of the slot position index, of shape
@@ -783,11 +794,12 @@ class KVCacheReplayLog:
                 batch and query group.
 
                 Args:
-                    token_pos: Token position where slice starts. Must be
+                    input_pos: Token position where slice starts. Must be
         -               `>= cache_length`.
                     num: Length of slice
-                    **kwargs: Dtype and device for the returned tensor. The default
-                        device is the one of the token chunks.
+                    dtype: Data type for returned tensor
+                    device: Device for returned tensor. The default device is the one
+                        of the token chunks.
 
                 Returns:
                     See above.

--- a/keys_values/kvcache/basics.py
+++ b/keys_values/kvcache/basics.py
@@ -463,7 +463,8 @@ class LastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
         self,
         input_pos: int,
         num: int,
-        **kwargs,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
     ) -> torch.Tensor:
         seq_length = self.__len__()
         if num <= 0 or input_pos < 0 or input_pos > seq_length - num:
@@ -474,11 +475,12 @@ class LastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
             raise ValueError(
                 f"input_pos = {input_pos} must be >= {self.cache_length} = cache_length"
             )
-        device = kwargs.get("device", torch.get_default_device())
+        if device is None:
+            device = torch.get_default_device()
         start = self.init_grace_tokens
         mod = self.cache_length - start
         current = (input_pos - self.cache_length) % mod + start
-        return positions_wrap_around(
+        result = positions_wrap_around(
             num=num,
             current=current,
             start=start,
@@ -487,7 +489,9 @@ class LastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
             n_query_groups=self._shape[1],
             device=device,
             return_tensor=True,
-        ).to(**kwargs)
+            dtype=dtype,
+        )
+        return result
 
 
 class LastRecentlyInsertedKVCache(KVCacheWithBuffers):
@@ -649,11 +653,12 @@ class LastRecentlyInsertedKVCache(KVCacheWithBuffers):
             )
 
     def token_positions(self) -> torch.Tensor:
-        return index_to_3d(
+        result = index_to_3d(
             self.token_pos[: self.current_length],
             self.batch_size,
             self.n_query_groups,
         )
+        return result
 
     def size_estimate(self) -> Tuple[int, Dict[str, int]]:
         tk_p = bitsize_of(self.token_pos)

--- a/keys_values/kvcache/buffers.py
+++ b/keys_values/kvcache/buffers.py
@@ -86,6 +86,7 @@ def positions_wrap_around(
     n_query_groups: int,
     device: torch.device,
     return_tensor: bool = False,
+    dtype: Optional[torch.dtype] = None,
 ) -> PositionsType:
     """
     Returns positions which form a range of length `num`, starting from
@@ -122,7 +123,9 @@ def positions_wrap_around(
         return current, current + num
     if device is None:
         raise ValueError("device must be given")
-    kwargs = dict(device=device, dtype=torch.int64)
+    if dtype is None:
+        dtype = torch.int64
+    kwargs = dict(device=device, dtype=dtype)
     positions = torch.arange(current, current + num1, **kwargs)
     if diff > 0:
         positions = torch.cat((positions, torch.arange(start, start + diff, **kwargs)))

--- a/keys_values/kvcache/gradient/accumulate.py
+++ b/keys_values/kvcache/gradient/accumulate.py
@@ -391,7 +391,6 @@ class GradientAccumulator:
             )
             cache_lengths.append(cache_length)
         # Checkpoint objects are selected from a pool
-        print("cache_lengths: " + str(cache_lengths))  # DEBUG
         checkpoints = self._select_checkpointers(cache_lengths)
 
         return cache_buffers, checkpoints

--- a/keys_values/kvcache/gradient/annotation.py
+++ b/keys_values/kvcache/gradient/annotation.py
@@ -16,8 +16,12 @@ from typing import Tuple, Optional, Dict, Any, Set, List
 
 import torch
 
-from keys_values.sdpa_wrapper import reorder_buffer_given_sort_index
-from keys_values.utils import shape_to_tuple, expand_index, repeat_interleave
+from keys_values.sdpa_wrapper import reorder_buffer_given_extra_info
+from keys_values.utils import (
+    shape_to_tuple,
+    expand_index,
+    repeat_interleave,
+)
 
 # The typical shape for `annotation.delta` in phase (1), matching annotations
 # against pack arguments, is
@@ -179,23 +183,27 @@ def create_random_index(
 def create_ext_annotations(
     key: torch.Tensor,
     value: torch.Tensor,
-    sort_index: Optional[torch.Tensor],
+    extra_info: Dict[str, Any],
+    extend_kv: bool,
     node_annotations: List[NodeAnnotation],
     annot_kwargs: Dict[str, Any],
+    verbose: bool,
 ):
     """
     Creates annotations "ext-key", "ext-value".
 
     Args:
-        node_annotations: Annotations appended here
-        annot_kwargs: Args for :class:`NodeAnnotation`, must contain
-            "layer_idx", "chunk_idx"
         key: Keys after reordering (optional) and repeat_interleave
             (optional)
         value: Values after reordering (optional) and repeat_interleave
             (optional)
-        sort_index: Sort index determining reordering (3D or 1D).
-            Stored in `NodeAnnotation.extra_info`.
+        extra_info: Information about reordering, see
+            :func:`reorder_key_value`. Stored in `NodeAnnotation.extra_info`.
+        extend_kv: Have `key`, `value` been extended to have
+            `shape[1] == n_head`?
+        node_annotations: Annotations appended here
+        annot_kwargs: Args for :class:`NodeAnnotation`, must contain
+            "layer_idx", "chunk_idx"
 
     """
     for buffer, name in ((key, "key"), (value, "value")):
@@ -209,20 +217,19 @@ def create_ext_annotations(
             dtype=torch.int32,
         )
         delta = buffer.gather(2, index)
-        if sort_index is not None:
-            extra_info = {"sort_index": sort_index}
-        else:
+        if not extra_info:
             extra_info = None
-        node_annotations.append(
-            NodeAnnotation(
-                **annot_kwargs,
-                kind=kind,
-                shape=shape,
-                index=index,
-                delta=delta,
-                extra_info=extra_info,
-            )
+        annotation = NodeAnnotation(
+            **annot_kwargs,
+            kind=kind,
+            shape=shape,
+            index=index,
+            delta=delta,
+            extra_info=extra_info,
         )
+        if verbose:
+            print("Create " + str(annotation))
+        node_annotations.append(annotation)
 
 
 def apply_ext_annotation(
@@ -248,8 +255,7 @@ def apply_ext_annotation(
             f"annotation.kind = {annotation.kind}, must be in {allowed_kinds}"
         )
     extra_info = annotation.extra_info
-    sort_index = None if extra_info is None else extra_info.get("sort_index")
-    if sort_index is not None:
-        buffer = reorder_buffer_given_sort_index(buffer, sort_index)
+    if extra_info is not None:
+        buffer = reorder_buffer_given_extra_info(buffer, **extra_info)
     buffer = repeat_interleave(buffer, n_head=target_dim1)
     return buffer

--- a/keys_values/kvcache/gradient/autograd_hooks.py
+++ b/keys_values/kvcache/gradient/autograd_hooks.py
@@ -31,6 +31,8 @@ from keys_values.utils import (
     expand_index,
     bytes_for_torch_dtype,
     shape_to_tuple,
+    is_index_1d,
+    index_to_3d,
 )
 
 
@@ -1307,22 +1309,25 @@ class CellComputationAutogradHooks(AutogradHooks):
     def _pack_4d_index(x: torch.Tensor) -> Optional[PackArgumentAsIndex]:
         """
         Helper for :meth:`pack_hook`. `x` must be 4D of integer
-        type. The assumption is that the final dimension is
-        broadcast-extended. We run a (randomized) test for this (full test is
-        too expensive). If positive, we return a packed version, otherwise
-        `None`.
+        type. If `x` is broadcast-extended along the final dimension, we
+        return the packed version, otherwise `None`.
+        Works also if `x` is essentially 1D.
 
         """
         if x.ndim != 4 or x.dtype not in (torch.int64, torch.int32, torch.int):
             return None
         final_dim = x.shape[-1]
-        rem_size = x.numel() // final_dim
-        check_ind = torch.randperm(rem_size)[:5].to(device=x.device)
-        arg1 = x.view(-1, final_dim)[check_ind, :]
-        arg2 = arg1[:, 0].unsqueeze(-1).expand(-1, final_dim)
-        if arg1.equal(arg2):
+        if x.stride()[-1] == 0 or final_dim == 1:
+            index_3d = x[..., 0]
+            if is_index_1d(index_3d):
+                index_3d = index_to_3d(
+                    index_3d[0, 0, :].clone(),
+                    *index_3d.shape[:-1],
+                )
+            else:
+                index_3d = index_3d.clone()
             return PackArgumentAsIndex(
-                index_3d=x[..., 0].clone(),
+                index_3d=index_3d,
                 final_dim=final_dim,
             )
         else:

--- a/keys_values/kvcache/gradient/train_attn_weights_replay.py
+++ b/keys_values/kvcache/gradient/train_attn_weights_replay.py
@@ -31,7 +31,6 @@ from keys_values.kvcache.attn_weights import (
     UpdateTokenPositionsGracePeriod,
 )
 from keys_values.kvcache.base import DefaultKVCache, KVCacheReplayLog
-from keys_values.tools.debug_utils import for_debug
 from keys_values.kvcache.gradient.autograd_hooks import Annotations
 from keys_values.kvcache.gradient.annotation import (
     NodeAnnotation,
@@ -44,7 +43,13 @@ from keys_values.kvcache.gradient.sdpa_op import (
     cat_on_buffers,
 )
 from keys_values.sdpa_wrapper import ReorderAnnotationCallback
-from keys_values.utils import expand_index, shape_to_tuple
+from keys_values.tools.debug_utils import for_debug
+from keys_values.utils import (
+    expand_index,
+    shape_to_tuple,
+    is_index_1d,
+    index_to_3d,
+)
 
 
 class TrainingAttnWeightsReplayCache(DefaultKVCache):
@@ -130,7 +135,6 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
         )
         if len(replay_log) == 0:
             raise ValueError("replay_log must not be empty")
-        self._device = replay_log.device
         if self.mha.use_eager_sdpa_always:
             raise ValueError(
                 "This replay cache does not support mha.use_eager_sdpa_always = True"
@@ -146,6 +150,7 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
                 "softcapping, or use FlexAttention by passing flexatt_args "
                 "when creating the MultiHeadSelfAttention object."
             )
+        self._device = replay_log.device
         self.replay_log = replay_log
         self._batch_size = batch_size
         self.kv_buffers = None
@@ -158,12 +163,14 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
         self._token_chunk_pos = None
         self._start_token_chunk_pos = None
         self._end_token_chunk_pos = None
-        shape = (batch_size, config.n_query_groups, cache_length)
+        # Try to keep `_token_positions` 1D. This works if the underlying
+        # KV cache has 1D token positions. Keeping `token_positions` 1D has
+        # important computational advantages downstream
         self._token_positions = torch.zeros(
-            shape,
+            (1, 1, cache_length),
             dtype=torch.int,
             device=self._device,
-        )
+        ).expand(batch_size, config.n_query_groups, -1)
         self.current_length = 0
         self._initialize_replay()
         self._debug_tensors = debug_tensors
@@ -281,7 +288,13 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
         """
         # Note: The `clone` is necessary to avoid this error during backward:
         # RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.IntTensor [5, 4, 512]] is at version 8; expected version 7 instead
-        return self._token_positions[:, :, : self.current_length].clone()
+        if is_index_1d(self._token_positions):
+            return index_to_3d(
+                self._token_positions[0, 0, : self.current_length].clone(),
+                *self._token_positions.shape[:-1],
+            )
+        else:
+            return self._token_positions[:, :, : self.current_length].clone()
 
     def max_forward_length(self) -> int:
         diff = self.cache_length - self.current_length
@@ -558,33 +571,6 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
                 )
             self._append_annotation(annotation)
 
-    @staticmethod
-    def _transform_index(
-        index: torch.Tensor,
-        sort_index: torch.Tensor,
-    ) -> torch.Tensor:
-        batch_size, n_query_groups, num, head_size = index.shape
-        si_len = sort_index.shape[-1]
-        assert sort_index.shape == (batch_size, n_query_groups, si_len)
-        sort_index = sort_index.to(dtype=index.dtype)
-        index = index[:, :, :, 0]
-        result = (
-            torch.empty_like(sort_index)
-            .scatter_(
-                2,
-                sort_index,
-                torch.arange(
-                    si_len,
-                    dtype=index.dtype,
-                    device=index.device,
-                )
-                .view(1, 1, -1)
-                .expand(batch_size, n_query_groups, -1),
-            )
-            .gather(2, index)
-        )
-        return expand_index(result, head_size)
-
     def _create_callback_after_creator(
         self,
         key: torch.Tensor,
@@ -609,16 +595,16 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
                     chunk_idx=chunk_idx,
                     kind=kind + "-value",
                 )
-            if NodeAnnotation.kind_is_scatter(kind):
-                annot_kwargs = dict(
-                    layer_idx=self.layer_idx,
-                    chunk_idx=chunk_idx,
-                )
-                annotation_callback = partial(
-                    create_ext_annotations,
-                    node_annotations=self._node_annotations.nodes,
-                    annot_kwargs=annot_kwargs,
-                )
+            annot_kwargs = dict(
+                layer_idx=self.layer_idx,
+                chunk_idx=chunk_idx,
+            )
+            annotation_callback = partial(
+                create_ext_annotations,
+                node_annotations=self._node_annotations.nodes,
+                annot_kwargs=annot_kwargs,
+                verbose=self.debug_print_annotations,
+            )
         if self._debug_tensors is not None:
             name = f"c{self._token_chunk_pos - 1}-l{self.layer_idx}-{kind}"
             if name in self._debug_tensors:
@@ -697,10 +683,14 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
         update_result = None
         if self.current_length >= self.cache_length:
             # scatter case
-            index_kwargs = {"dtype": torch.int32, "device": self._device}
             index = self.replay_log.extract_index(
-                self.input_pos, num, **index_kwargs
+                self.input_pos,
+                num,
+                dtype=torch.int32,
+                device=self._device,
             ).detach()
+            if is_index_1d(self._token_positions) and not is_index_1d(index):
+                self._token_positions = self._token_positions.contiguous()
             update_result = update_token_positions(
                 token_positions=self._token_positions,
                 input_pos=self.input_pos,

--- a/keys_values/kvcache/gradient/train_attn_weights_replay_old.py
+++ b/keys_values/kvcache/gradient/train_attn_weights_replay_old.py
@@ -22,15 +22,12 @@ from keys_values.attention import (
     KeysAndValues,
     DefaultKeysAndValues,
 )
-from keys_values.tools.debug_utils import for_debug
 from keys_values.kvcache.attn_weights import (
     update_token_positions,
     UpdateTokenPositionsGracePeriod,
 )
 from keys_values.kvcache.base import DefaultKVCache, KVCacheReplayLog
-from keys_values.kvcache.gradient.autograd_hooks import (
-    Annotations,
-)
+from keys_values.kvcache.gradient.autograd_hooks import Annotations
 from keys_values.kvcache.gradient.annotation import (
     NodeAnnotation,
     create_random_index,
@@ -40,7 +37,13 @@ from keys_values.kvcache.gradient.sdpa_op import (
     KVCacheCatUpdateAndSDPAFunction,
     KVCacheScatterUpdateAndSDPAFunction,
 )
-from keys_values.utils import expand_index, shape_to_tuple
+from keys_values.tools.debug_utils import for_debug
+from keys_values.utils import (
+    expand_index,
+    shape_to_tuple,
+    is_index_1d,
+    index_to_3d,
+)
 
 
 class TrainingAttnWeightsReplayCacheOld(DefaultKVCache):
@@ -101,12 +104,14 @@ class TrainingAttnWeightsReplayCacheOld(DefaultKVCache):
         self._token_chunk_pos = None
         self._start_token_chunk_pos = None
         self._end_token_chunk_pos = None
-        shape = (batch_size, config.n_query_groups, cache_length)
+        # Try to keep `_token_positions` 1D. This works if the underlying
+        # KV cache has 1D token positions. Keeping `token_positions` 1D has
+        # important computational advantages downstream
         self._token_positions = torch.zeros(
-            shape,
+            (1, 1, cache_length),
             dtype=torch.int,
             device=self._device,
-        )
+        ).expand(batch_size, config.n_query_groups, -1)
         self.current_length = 0
         self._initialize_replay()
         self._debug_tensors = debug_tensors
@@ -206,7 +211,13 @@ class TrainingAttnWeightsReplayCacheOld(DefaultKVCache):
         # using the :class:`KVCacheUpdateAndSDPAFunction` or
         # :class:`SDPAFunction` operator:
         # RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.IntTensor [5, 4, 512]] is at version 8; expected version 7 instead
-        return self._token_positions[:, :, : self.current_length].clone()
+        if is_index_1d(self._token_positions):
+            return index_to_3d(
+                self._token_positions[0, 0, : self.current_length].clone(),
+                *self._token_positions.shape[:-1],
+            )
+        else:
+            return self._token_positions[:, :, : self.current_length].clone()
 
     def max_forward_length(self) -> int:
         diff = self.cache_length - self.current_length
@@ -561,10 +572,14 @@ class TrainingAttnWeightsReplayCacheOld(DefaultKVCache):
         update_result = None
         if self.current_length >= self.cache_length:
             # scatter case
-            index_kwargs = {"dtype": torch.int32, "device": self._device}
             index = self.replay_log.extract_index(
-                self.input_pos, num, **index_kwargs
+                self.input_pos,
+                num,
+                dtype=torch.int32,
+                device=self._device,
             ).detach()
+            if is_index_1d(self._token_positions) and not is_index_1d(index):
+                self._token_positions = self._token_positions.contiguous()
             update_result = update_token_positions(
                 token_positions=self._token_positions,
                 input_pos=self.input_pos,

--- a/keys_values/kvcache/test_utils.py
+++ b/keys_values/kvcache/test_utils.py
@@ -133,6 +133,12 @@ def random_index(
     batch_size: Optional[int] = None,
     device: Optional[torch.device] = None,
 ):
+    """
+    Creates 3D random index of shape `(batch_size, params.n_query_groups, num)`.
+    Each `result[b, h, :]` is a random subset of `range(start, end)`, no
+    duplicates.
+
+    """
     if batch_size is None:
         batch_size = params.max_batch_size
     if num is None:

--- a/keys_values/sdpa_wrapper.py
+++ b/keys_values/sdpa_wrapper.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from functools import partial
-from typing import List, Optional, Union, Tuple, Callable
+from typing import List, Optional, Union, Tuple, Callable, Dict, Any
 
 import torch
 from torch.nn.attention import SDPBackend
 
 from keys_values.attention_utils import pytorch_scaled_dot_product_attention
-from keys_values.utils import expand_index, is_index_1d
+from keys_values.utils import expand_index, is_index_1d, index_to_3d
 
 
 def sdpa_check_args(
@@ -47,9 +47,20 @@ def sdpa_check_args(
     return batch_size, n_head, n_query_groups, q_len, kv_len, head_size
 
 
+# `callback(key, value, extra_info, extend_kv)`
 ReorderAnnotationCallback = Callable[
-    [torch.Tensor, torch.Tensor, Optional[torch.Tensor]], None
+    [torch.Tensor, torch.Tensor, Dict[str, Any], bool], None
 ]
+
+
+def zeropad_query_on_left(query: torch.Tensor, num: int) -> torch.Tensor:
+    assert query.ndim == 4
+    fill_left = torch.zeros(
+        (1, 1, 1, 1),
+        dtype=query.dtype,
+        device=query.device,
+    ).expand(*query.shape[:2], num, query.shape[-1])
+    return torch.cat((fill_left, query), dim=2)
 
 
 def scaled_dot_product_attention(
@@ -62,6 +73,7 @@ def scaled_dot_product_attention(
     sdpa_kernels: Optional[Union[SDPBackend, List[SDPBackend]]] = None,
     do_filter_kernels: bool = False,
     annotation_callback: Optional[ReorderAnnotationCallback] = None,
+    sort_if_3d: bool = False,
 ) -> Tuple[torch.Tensor, Optional[List[SDPBackend]]]:
     """
     Wraps `F.scaled_dot_product_attention` in a way which supports
@@ -85,7 +97,7 @@ def scaled_dot_product_attention(
     `token_positions`, since reordering buffer entries takes time and memory.
 
     Args:
-        query: Queries, shape `(batch_size, n_heads, q_len, head_size)`
+        query: Queries, shape `(batch_size, n_head, q_len, head_size)`
         key: Keys, shape `(batch_size, n_query_groups, kv_len, head_size)`
         value: Values, shape `(batch_size, n_query_groups, kv_len, head_size)`
         scale_factor: Scale factor for attention
@@ -99,12 +111,13 @@ def scaled_dot_product_attention(
             `sdpa_kernels`.
         annotation_callback: If this is given and `key, value` are reordered,
             the results are passed to this callback.
+        sort_if_3d: See :func:`reorder_key_value`.
 
     Returns:
         Attention outputs, shape `(batch_size, n_heads, q_len, head_size)`
 
     """
-    batch_size, n_head, _, q_len, kv_len, head_size = sdpa_check_args(
+    batch_size, n_head, n_query_groups, q_len, kv_len, head_size = sdpa_check_args(
         query,
         key,
         value,
@@ -116,7 +129,7 @@ def scaled_dot_product_attention(
             raise ValueError(
                 f"Without token_positions, must have input_pos + q_len = {input_pos + q_len} == {kv_len} = kv_len"
             )
-        sort_index = None
+        extra_info = dict()
     else:
         # Reorder entries in `key`, `value`, so that new entries are on the
         # right. New entries are those with `token_positions >= input_pos`.
@@ -131,26 +144,24 @@ def scaled_dot_product_attention(
             raise ValueError(
                 f"token_positions.shape = {token_positions.shape}, key.shape = {key.shape}: Not compatible"
             )
-        key, value, sort_index = reorder_key_value(
+        key, value, extra_info = reorder_key_value(
             key,
             value,
             token_positions.detach(),
+            input_pos,
+            q_len,
+            sort_if_3d,
         )
 
     # At this point, the new entries in `key`, `value`, corresponding to the
     # `query` tokens, are on the right end. Causal masking works if `query`
     # is zero-padded on the left
     if q_len < kv_len:
-        fill_left = torch.zeros(
-            (1, 1, 1, 1),
-            dtype=query.dtype,
-            device=query.device,
-        ).expand(batch_size, n_head, kv_len - q_len, head_size)
-        query = torch.cat((fill_left, query), dim=2)
+        query = zeropad_query_on_left(query, kv_len - q_len)
     if annotation_callback is not None:
         annotation_callback = partial(
             annotation_callback,
-            sort_index=sort_index,
+            extra_info=extra_info,
         )
     full_y, filtered_kernels = pytorch_scaled_dot_product_attention(
         query=query,
@@ -168,30 +179,211 @@ def scaled_dot_product_attention(
     return attn_output, filtered_kernels
 
 
+def _extract_index_gather_scatter(
+    token_positions: torch.Tensor,
+    input_pos: int,
+    q_len: int,
+    check_token_pos: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Determines two indexes which are used to permute `key`, `value` so
+    that information corresponding to the largest token positions
+    `>= input_pos` moves to the right end. This "two step" solution is an
+    alternative to sorting `token_positions`, which is more expensive if
+    the index is 3D.
+
+    Both `index_gat`, `index_scat` contain the same entries, namely the
+    positions of entries `>= input_pos` in `token_positions`. But they
+    are ordered differently:
+    - `index_gat`: Order in which entries `range(index_pos,
+        index_pos + q_len)` appear in `token_positions`.
+    - `index_scat`: `index_sorted` is permuted by the inverse of the
+        permutation which sorts`token_positions[:, :, (-q_len):]`.
+
+    This ensures that things work out if there are overlaps between
+    `index_sorted` and the right end of length `q_len`.
+    See technical report for details.
+
+    Args:
+        token_positions: Token positions in KV cache
+        input_pos: Position in input sequence, must be `> 0`
+        q_len: Length of query sequence
+        check_token_pos: If `True`, check that `token_positions` is valid.
+            Use this for testing. Must be `False` if this is used as part
+            of a computation graph
+
+    Returns:
+        `(index_gat, index_scat)`, each of shape
+        `(batch_size, n_query_groups, q_len)`. See above.
+
+    """
+    batch_size, n_query_groups, _ = token_positions.shape
+    new_entries_mask = token_positions >= input_pos
+    if check_token_pos:
+        dummy = new_entries_mask.sum(dim=-1)
+        if not (dummy == q_len).all().item():
+            raise ValueError(
+                f"token_positions must have entries [{input_pos}, {input_pos + q_len}) in every slice. dummy = {dummy}"
+            )
+    nz0, nz1, nz2 = new_entries_mask.nonzero(as_tuple=True)
+    if check_token_pos:
+        kwargs = dict(dtype=nz0.dtype, device=nz0.device)
+        nz0_should_be = (
+            torch.arange(batch_size, **kwargs)[:, None, None]
+            .expand(-1, n_query_groups, q_len)
+            .flatten()
+        )
+        if not nz0.equal(nz0_should_be):
+            raise ValueError(f"nz0 = {nz0}, must equal to {nz0_should_be}")
+        nz1_should_be = (
+            torch.arange(n_query_groups, **kwargs)[None, :, None]
+            .expand(batch_size, -1, q_len)
+            .flatten()
+        )
+        if not nz1.equal(nz1_should_be):
+            raise ValueError(f"nz1 = {nz1}, must equal to {nz1_should_be}")
+    elif nz2.numel() != batch_size * n_query_groups * q_len:
+        raise ValueError(
+            f"Invalid token_positions: Number of entries in [{input_pos}, {input_pos + q_len}) must be {batch_size * n_query_groups * q_len}, but is {nz2.numel()}"
+        )
+    index_sorted = nz2.view(batch_size, n_query_groups, q_len)
+    # `index_gat`: Order in which entries `range(index_pos, index_pos + q_len)`
+    # appear in `token_positions`.
+    new_positions = (
+        token_positions[nz0, nz1, nz2].view(
+            batch_size,
+            n_query_groups,
+            q_len,
+        )
+        - input_pos
+    )
+    index_gat = torch.zeros_like(index_sorted).scatter(
+        -1,
+        index=new_positions,
+        src=index_sorted,
+    )
+    # index_scat`: `index_sorted` is permuted by the inverse of the
+    # permutation which sorts`token_positions[:, :, (-q_len):]`
+    sort_final = torch.argsort(token_positions[:, :, (-q_len):], dim=-1)
+    inv_sort_final = torch.zeros_like(sort_final).scatter(
+        -1,
+        index=sort_final,
+        src=index_to_3d(
+            torch.arange(
+                q_len,
+                dtype=sort_final.dtype,
+                device=sort_final.device,
+            ),
+            batch_size,
+            n_query_groups,
+        ),
+    )
+    index_scat = index_sorted.gather(-1, inv_sort_final)
+    return index_gat, index_scat
+
+
+def _reorder(
+    x: torch.Tensor,
+    index_gat: torch.Tensor,
+    index_scat: torch.Tensor,
+    do_single_step: bool = False,
+) -> torch.Tensor:
+    """
+    Exchange two parts of size `(batch_size, n_query_groups, q_len, head_size)`
+    in `x`. One is `x.gather(2, index_gat)`, the other is
+    `x[:, :, (-q_len):, :]`. `index_gat[b, h, :]` and `index_scat[b, h, :]`
+    have the same values, but in different orderings. `index_scat` is used
+    with `scatter`. This is needed in order to not make mistakes when there
+    are overlaps.
+
+    """
+    q_len = index_gat.shape[-1]
+    _, _, kv_len, head_size = x.shape
+    x_new = x.gather(2, expand_index(index_gat, head_size))
+    x_right = x[:, :, (-q_len):, :]
+    if not do_single_step:
+        x = x.scatter(2, expand_index(index_scat, head_size), x_right.clone())
+        x = torch.cat((x[:, :, :(-q_len), :], x_new), dim=2)
+    else:
+        # Note: `index_scat`, `index_right` can overlap, in which case the
+        # outcome of `scatter` can be non-deterministic. Does this matter?
+        # Does it make a difference time-wise?
+        index_right = torch.arange(
+            kv_len - q_len,
+            kv_len,
+            dtype=index_gat.dtype,
+            device=index_gat.device,
+        )[None, None, :].expand(*x.shape[:2], -1)
+        x = x.scatter(
+            2,
+            index=expand_index(
+                torch.cat((index_scat, index_right), dim=-1),
+                head_size,
+            ),
+            src=torch.cat((x_right, x_new), dim=2),
+        )
+    return x
+
+
 def reorder_key_value(
     key: torch.Tensor,
     value: torch.Tensor,
     token_positions: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    if not is_index_1d(token_positions):
-        sort_index = torch.argsort(token_positions, dim=-1)
-    else:
+    input_pos: int,
+    q_len: int,
+    sort_if_3d: bool = False,
+    check_token_pos: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+    """
+    Reorder `key, value` tensors using permutations (for each b, h) which, if
+    applied to `token_positions`, place `input_pos:(input_pos + q_len)` at the
+    right end. This is done in different ways:
+
+    * If `token_positions` is essentially 1D, we use the sorting permutation,
+      returned as `sort_index` (1D)
+    * If `token_positions` is 3D, we use the sorting permutation if
+      `sort_if_3d == True`. Otherwise, we use a two-step permutation,
+      parameterized by `index_gat`, `index_scat`. These are cheaper to obtain.
+
+    """
+    if is_index_1d(token_positions):
         # `token_positions` is essentially 1D
-        sort_index = torch.argsort(token_positions[0, 0, :])
+        extra_info = dict(sort_index=torch.argsort(token_positions[0, 0, :]))
+    elif sort_if_3d:
+        extra_info = dict(sort_index=torch.argsort(token_positions, dim=-1))
+    else:
+        index_gat, index_scat = _extract_index_gather_scatter(
+            token_positions,
+            input_pos,
+            q_len,
+            check_token_pos,
+        )
+        extra_info = dict(index_gat=index_gat, index_scat=index_scat)
     return (
-        reorder_buffer_given_sort_index(key, sort_index),
-        reorder_buffer_given_sort_index(value, sort_index),
-        sort_index,
+        reorder_buffer_given_extra_info(key, **extra_info),
+        reorder_buffer_given_extra_info(value, **extra_info),
+        extra_info,
     )
 
 
-def reorder_buffer_given_sort_index(
+def reorder_buffer_given_extra_info(
     buffer: torch.Tensor,
-    sort_index: torch.Tensor,
+    **kwargs,
 ) -> torch.Tensor:
-    if sort_index.ndim == 3:
-        index = expand_index(sort_index, buffer.shape[-1])
-        buffer = torch.gather(buffer, -2, index)
+    """
+    Same as :func:`reorder_key_value`, but the permutation indices are
+    given here, not determined.
+
+    """
+    sort_index = kwargs.get("sort_index")
+    if sort_index is not None:
+        if sort_index.ndim == 1:
+            buffer = buffer[:, :, sort_index, :]
+        else:
+            index = expand_index(sort_index, buffer.shape[-1])
+            buffer = torch.gather(buffer, -2, index)
     else:
-        buffer = buffer[:, :, sort_index, :]
+        index_gat = kwargs["index_gat"]
+        index_scat = kwargs["index_scat"]
+        buffer = _reorder(buffer, index_gat, index_scat)
     return buffer

--- a/keys_values/tools/debug_utils.py
+++ b/keys_values/tools/debug_utils.py
@@ -16,6 +16,8 @@ from typing import Dict, Optional, Callable, Any, List
 
 import torch
 
+from keys_values.utils import is_index_1d
+
 
 def for_debug(x: torch.Tensor) -> torch.Tensor:
     return x.detach().to(device=torch.device("cpu")).clone()
@@ -166,3 +168,8 @@ def debug_compare_dicts(
             for name, msg in exc_caught:
                 print(f"\n    [{name}]\n{msg}")
             raise rethrow_ex
+
+
+def debug_token_positions(index: Optional[torch.Tensor], name: str):
+    if index is not None and not is_index_1d(index):
+        print(f"{name}: token_positions: {index.stride()}")

--- a/keys_values/utils.py
+++ b/keys_values/utils.py
@@ -81,8 +81,19 @@ def index_to_3d(index: torch.Tensor, dim0: int, dim1: int) -> torch.Tensor:
 
 
 def is_index_1d(index: torch.Tensor) -> bool:
+    """
+    Tests whether `index` is inherently 1D, i.e. obtained by :func:`index_to_3d`.
+    Attention: If a dimension is length 1, its stride value may not be 0.
+
+    """
     ndim = index.ndim
-    return index.stride() == (0,) * (ndim - 1) + (1,)
+    if ndim == 1:
+        return True
+    stride = index.stride()
+    shape = tuple(index.shape)
+    return stride[-1] == 1 and all(
+        s == 0 or l == 1 for s, l in zip(stride[:-1], shape[:-1])
+    )
 
 
 def need_repeat_interleave(n_head: int, n_query_groups: int) -> bool:

--- a/test/kvcache/test_autograd_hooks.py
+++ b/test/kvcache/test_autograd_hooks.py
@@ -25,15 +25,39 @@ from keys_values.kvcache.gradient.annotation import (
     create_random_index,
     MAX_DELTA_TRANS_LENGTH,
 )
-from keys_values.kvcache.gradient.train_attn_weights_replay import (
-    TrainingAttnWeightsReplayCache,
-)
 from keys_values.kvcache.test_utils import (
     random_tensor,
     available_backends,
     random_index,
 )
 from keys_values.utils import expand_index, repeat_interleave, randint_torch
+
+
+def _transform_index(
+    index: torch.Tensor,
+    sort_index: torch.Tensor,
+) -> torch.Tensor:
+    batch_size, n_query_groups, num, head_size = index.shape
+    si_len = sort_index.shape[-1]
+    assert sort_index.shape == (batch_size, n_query_groups, si_len)
+    sort_index = sort_index.to(dtype=index.dtype)
+    index = index[:, :, :, 0]
+    result = (
+        torch.empty_like(sort_index)
+        .scatter_(
+            2,
+            sort_index,
+            torch.arange(
+                si_len,
+                dtype=index.dtype,
+                device=index.device,
+            )
+            .view(1, 1, -1)
+            .expand(batch_size, n_query_groups, -1),
+        )
+        .gather(2, index)
+    )
+    return expand_index(result, head_size)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +139,7 @@ def test_extract_delta(device, dtype):
         delta = repeat_interleave(keys.gather(2, ext_index), n_head)
         assert delta.shape == (batch_size, n_head, MAX_DELTA_TRANS_LENGTH, head_size)
         ext_index = repeat_interleave(
-            TrainingAttnWeightsReplayCache._transform_index(
+            _transform_index(
                 index=ext_index,
                 sort_index=sort_index,
             ),

--- a/test/kvcache/test_basics.py
+++ b/test/kvcache/test_basics.py
@@ -25,7 +25,7 @@ from keys_values.kvcache.test_utils import (
     available_backends,
     product_with_devices,
 )
-from keys_values.utils import randint_torch
+from keys_values.utils import randint_torch, index_to_3d, is_index_1d
 
 
 @pytest.mark.parametrize(
@@ -153,3 +153,26 @@ def test_incremental_versus_singlepass(device, dtype, tol_kwargs):
                 y_sshot[:, pos : (pos + 1), :],
                 **tol_kwargs,
             )
+
+
+def test_index_to_3d():
+    for shape in [
+        (2, 3, 4),
+        (1, 2, 3),
+        (2, 1, 3),
+        (1, 1, 2),
+        (3, 1, 1),
+        (1, 2, 1),
+        (1, 1, 1),
+    ]:
+        size = shape[2]
+        index = torch.arange(size)
+        result = index_to_3d(index, *shape[:-1])
+        assert is_index_1d(result), ("type 1", shape, result.shape, result.stride())
+        if size > 1:
+            # Can change the 1D row, tensor remains 1D
+            result[0, 0, :size] = 321
+            assert is_index_1d(result), ("type 3", shape, result.shape, result.stride())
+        index = torch.arange(size * 2)[:size]
+        result = index_to_3d(index, *shape[:-1])
+        assert is_index_1d(result), ("type 2", shape, result.shape, result.stride())

--- a/test/kvcache/test_gradient.py
+++ b/test/kvcache/test_gradient.py
@@ -25,6 +25,7 @@ from keys_values.finetune.utils import (
     may_match_twice_flex_attention_sdpa,
     may_match_twice_fused_eager_sdpa,
 )
+from keys_values.flex_attention import FlexAttentionArgs
 from keys_values.kvcache.gradient.accumulate import GradientAccumulator
 from keys_values.kvcache.gradient.autograd_hooks import CellComputationAutogradHooks
 from keys_values.kvcache.gradient.cell import GetInputSlice, WriteOutputsSlice
@@ -53,8 +54,9 @@ def make_write_outputs_slice(x: torch.Tensor) -> WriteOutputsSlice:
 
 def args_gradient_row_of_cells():
     setups = [
-        a + b + (c,)
-        for a, b, c in product(
+        a + b + (c, d)
+        for d, a, b, c in product(
+            available_backends(),
             [
                 ("lastrec", dict()),
                 ("h2o", {"replay_log_blocksize": 64}),
@@ -75,41 +77,62 @@ def args_gradient_row_of_cells():
     tol_kwargs = dict(atol=3e-5, rtol=2e-5)
     tol_kwargs2 = dict(atol=0.0005, rtol=0.001)
     tol_kwargs3 = dict(atol=0.0015, rtol=0.01)
+    # Note: We use `flex_attention` for GPU, zero-padded query SDPA for
+    # CPU. This is why limits depend on device
     return [
-        a + b + (c,)
-        for c, (a, b) in product(
-            available_backends(),
+        a + b
+        for a, b in (
             zip(
                 setups,
                 [
                     ([4, 8, 8, 12], tol_kwargs),
-                    ([8, 14, 14, 12], tol_kwargs),
+                    ([4, 10, 10, 12], tol_kwargs),
                     ([4, 8, 8, 8, 12], tol_kwargs),
-                    ([8, 14, 14, 16, 12], tol_kwargs3),
+                    ([4, 10, 10, 8, 12], tol_kwargs3),
                     ([4, 8, 8, 12], tol_kwargs),
                     ([8, 14, 14, 12], tol_kwargs),
                     ([4, 8, 8, 8, 12], tol_kwargs),
-                    ([8, 14, 14, 16, 12], tol_kwargs2),
+                    ([8, 14, 14, 10, 12], tol_kwargs2),
                     ([4, 8, 8, 12], tol_kwargs),
                     ([8, 14, 14, 12], tol_kwargs),
                     ([4, 8, 8, 8, 12], tol_kwargs),
-                    ([8, 14, 14, 16, 12], tol_kwargs2),
+                    ([8, 14, 14, 10, 12], tol_kwargs2),
                     ([4, 8, 8, 12], tol_kwargs),
                     ([16, 26, 26, 12], tol_kwargs),
                     ([4, 8, 8, 8, 12], tol_kwargs),
-                    ([16, 26, 26, 20, 12], tol_kwargs3),
+                    ([16, 26, 26, 14, 12], tol_kwargs3),
                     ([4, 8, 8, 12], tol_kwargs),
                     ([16, 26, 26, 12], tol_kwargs),
                     ([4, 8, 8, 8, 12], tol_kwargs),
-                    ([16, 26, 26, 20, 12], tol_kwargs3),
+                    ([16, 26, 26, 14, 12], tol_kwargs3),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([0, 4, 4, 12], tol_kwargs),
+                    ([4, 8, 8, 8, 12], tol_kwargs),
+                    ([0, 4, 4, 4, 12], tol_kwargs3),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 6, 12], tol_kwargs2),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 8, 12], tol_kwargs),
+                    ([4, 8, 8, 6, 12], tol_kwargs2),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([12, 20, 20, 12], tol_kwargs),
+                    ([4, 8, 8, 8, 12], tol_kwargs),
+                    ([12, 20, 20, 10, 12], tol_kwargs3),
+                    ([4, 8, 8, 12], tol_kwargs),
+                    ([12, 20, 20, 12], tol_kwargs),
+                    ([4, 8, 8, 8, 12], tol_kwargs),
+                    ([12, 20, 20, 10, 12], tol_kwargs3),
                 ],
-            ),
+            )
         )
     ]
 
 
 @pytest.mark.parametrize(
-    "cache_name, cache_kwargs, cache_lengths, tokens_per_chunk, chunks_per_cell, use_old_cache, limit_num_unmatched, tol_kwargs, device",
+    "cache_name, cache_kwargs, cache_lengths, tokens_per_chunk, chunks_per_cell, use_old_cache, device, limit_num_unmatched, tol_kwargs",
     args_gradient_row_of_cells(),
 )
 def test_gradient_row_of_cells(
@@ -119,9 +142,9 @@ def test_gradient_row_of_cells(
     tokens_per_chunk,
     chunks_per_cell,
     use_old_cache,
+    device,
     limit_num_unmatched,
     tol_kwargs,
-    device,
 ):
     seed = 31415927
     torch.random.manual_seed(seed)
@@ -129,6 +152,18 @@ def test_gradient_row_of_cells(
     print(
         f"cache_length={cache_lengths}\ntokens_per_chunk={tokens_per_chunk}\nchunks_per_cell={chunks_per_cell}\nuse_old_cache={use_old_cache}"
     )
+    error_prefix = "\n".join(
+        [
+            f"cache_name:       {cache_name}",
+            f"cache_kwargs:     {cache_kwargs}",
+            f"cache_lengths:    {cache_lengths}",
+            f"tokens_per_chunk: {tokens_per_chunk}",
+            f"chunks_per_cell:  {chunks_per_cell}",
+            f"use_old_cache:    {use_old_cache}",
+            f"device:           {device}",
+        ]
+    )
+    print(error_prefix)
 
     use_autograd_hooks = True
     do_gradient_testing = True
@@ -183,8 +218,14 @@ def test_gradient_row_of_cells(
         cache_length=cache_lengths[0],
         dtype=dtype,
     )
+    if device.type == "cuda":
+        mha_kwargs = dict(
+            flexatt_args=FlexAttentionArgs(q_lens=[max(tokens_per_chunk[1:])])
+        )
+    else:
+        mha_kwargs = dict()
     with torch.device(device):
-        gpt_model = GPT(config)
+        gpt_model = GPT(config, **mha_kwargs)
         gpt_model.apply(gpt_model._init_weights)  # Initialization
     gpt_model.set_start_of_layer_hook(start_of_layer_hook)
     token_idxs = torch.randint(
@@ -199,6 +240,7 @@ def test_gradient_row_of_cells(
             name=cache_name + "-" + qname,
             params=replace(params, cache_length=cache_length),
             block_idx=block_idx,
+            **mha_kwargs,
             **cache_kwargs,
         )
         kv_cache.switch_replay_logging(True)
@@ -367,6 +409,7 @@ def test_gradient_row_of_cells(
         logs = accumulator.annotation_usage_logs()
         print("\nAnnotation usage logs (per cell):")
         num_unmatched = []
+        sum_unmatched_annots = 0
         for first_chunk_idx, annotation_usage in sorted(
             list(logs.items()),
             reverse=True,
@@ -374,8 +417,16 @@ def test_gradient_row_of_cells(
             print(f"\nCell(first_chunk_idx {first_chunk_idx}):")
             print(annotation_usage.report())
             num_unmatched.append(len(annotation_usage.unmatched_pack_args))
-            # All annotations should be matched:
-            assert len(annotation_usage.unmatched_annotations) == 0
+            # We don't care about unmatched cat/scatter, they are dealt with
+            # anyway. They do happen if `autograd` decides to not create a node
+            # for them in the graph.
+            num_unmatched_annots = (
+                len(annotation_usage.unmatched_annotations)
+                - annotation_usage.num_unmatched_scatter_cat
+            )
+            sum_unmatched_annots += num_unmatched_annots
+        # All non-(scatter/cat) annotations should be matched:
+        assert sum_unmatched_annots == 0
         assert len(num_unmatched) == len(limit_num_unmatched)
         assert all(a <= b for a, b in zip(num_unmatched, limit_num_unmatched)), (
             num_unmatched,

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -21,12 +21,12 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from keys_values.config import Config
 from litgpt.model import (
     apply_rope,
     build_rope_cache,
     batched_index_select,
 )
+from litgpt.utils import _RunIf
 
 from keys_values.array_limit import TemporaryArrayLimit
 from keys_values.attention import (
@@ -41,6 +41,8 @@ from keys_values.attention_utils import (
     sample_token_positions,
     ENTRIES_PER_GB,
 )
+from keys_values.config import Config
+from keys_values.flex_attention import FlexAttentionArgs
 from keys_values.head_model import CrossEntropyOnLogits
 from keys_values.head_model_factory import HeadModelFactory
 from keys_values.kvcache.base import KVCache, KVCacheParams, DefaultKVCache
@@ -51,11 +53,12 @@ from keys_values.kvcache.test_utils import (
     product_with_devices,
     available_backends,
     create_kv_cache,
+    random_args_cache_forward,
 )
 from keys_values.model import GPT, CausalSelfAttention
 from keys_values.optimize.clone_model import clone_model_shard_via_flat_vectors
 from keys_values.pos_encoding import LinearPositionEncoding
-from keys_values.utils import repeat_interleave, randint_torch
+from keys_values.utils import repeat_interleave, randint_torch, index_to_3d
 
 
 @pytest.mark.parametrize(
@@ -951,3 +954,243 @@ def test_mha_is_passed_on(device):
         tr_caches,
         prefix="Training replay caches: ",
     )
+
+
+@pytest.mark.parametrize(
+    *product_with_devices(
+        [
+            (4, 2, 128, 512, 512, torch.float16, 5e-5),
+            (4, 4, 8, 256, 342, torch.bfloat16, 0.0004),
+            (8, 4, 128, 136, 256, torch.float16, 0.00075),
+            (12, 4, 16, 512, 512, torch.bfloat16, 0.0006),
+            (24, 8, 2, 512, 768, torch.float16, 7e-5),
+            (9, 3, 128, 512, 664, torch.bfloat16, 0.0006),
+            (12, 4, 16, 512, 512, torch.float16, 0.00015),
+        ],
+        "n_head, n_query_groups, q_len, kv_len, input_pos, dtype, atol",
+    ),
+)
+def test_reorder_key_value_tp_3d(
+    device,
+    n_head,
+    n_query_groups,
+    q_len,
+    kv_len,
+    input_pos,
+    dtype,
+    atol,
+):
+    """
+    We allow for some numerical errors on a GPU device. This is because
+    FlexAttention is used there, which does not cast to `float32` internally.
+    Even though `sort_if_3d` only determines the ordering of entries in
+    `key, value`, this results in different error patterns (of roughly the
+    same size), because internally FlexAttention uses tiling, so it matters
+    where each entry is located.
+
+    """
+    seed = 31415927
+    torch.manual_seed(seed)
+
+    batch_size = 2
+    head_size = 32
+
+    config = Config.from_name(
+        "gemma-2-27b",
+        block_size=input_pos + 2 * kv_len,
+        sliding_window_size=None,
+        attention_logit_softcapping=None,
+        n_layer=1,
+        n_query_groups=n_query_groups,
+        n_head=n_head,
+        n_embd=n_head * head_size,
+        intermediate_size=n_head * head_size * 3,
+        rotary_percentage=1.0,
+    )
+    params = KVCacheParams.from_config(
+        config=config,
+        max_batch_size=batch_size,
+        cache_length=kv_len,
+        dtype=dtype,
+    )
+    names = ["padded-query"]
+    mha_pairs = [
+        [
+            MultiHeadSelfAttention(config, sort_if_3d=sort_if_3d)
+            for sort_if_3d in (True, False)
+        ]
+    ]
+    if device.type == "cuda":
+        # FlexAttention: Only on GPU
+        # No internal zero-padding of query
+        flexatt_args_no_zp = FlexAttentionArgs(q_lens=[q_len])
+        names.append("flex-att-no-zp")
+        mha_pairs.append(
+            [
+                MultiHeadSelfAttention(
+                    config, flexatt_args=flexatt_args_no_zp, sort_if_3d=sort_if_3d
+                )
+                for sort_if_3d in (True, False)
+            ]
+        )
+        # Internal zero-padding of query
+        flexatt_args_zp = FlexAttentionArgs(q_lens=[q_len + 8])
+        names.append("flex-att-zp")
+        mha_pairs.append(
+            [
+                MultiHeadSelfAttention(
+                    config, flexatt_args=flexatt_args_zp, sort_if_3d=sort_if_3d
+                )
+                for sort_if_3d in (True, False)
+            ]
+        )
+        test_kwargs = dict(atol=atol, rtol=1)
+    else:
+        test_kwargs = dict()
+
+    last_ex = None
+    for name, mhas in zip(names, mha_pairs):
+        # Sample data
+        data = random_args_cache_forward(
+            params,
+            num=kv_len,
+            vocab_size=config.vocab_size,
+            device=device,
+        )
+        token_positions = sample_token_positions(
+            batch_size,
+            n_query_groups,
+            q_len,
+            kv_len,
+            input_pos,
+            device,
+        )
+        outputs = [
+            mha(
+                query=data["query"][:, :, :q_len, :],
+                k_and_v=DefaultKeysAndValues(data["key"], data["value"]),
+                block_idx=0,
+                input_pos=input_pos,
+                token_positions=token_positions,
+            )[0]
+            for mha in mhas
+        ]
+        try:
+            torch.testing.assert_close(outputs[0], outputs[1], **test_kwargs)
+        except AssertionError as ex:
+            print(f"\n{name}:\n" + str(ex))
+            last_ex = ex
+    if last_ex is not None:
+        raise last_ex
+
+
+@_RunIf(min_cuda_gpus=1)
+@pytest.mark.parametrize(
+    "n_head, n_query_groups, q_len, kv_len, input_pos, dtype",
+    [
+        (4, 2, 128, 512, 512, torch.float16),
+        (4, 4, 8, 256, 342, torch.bfloat16),
+        (8, 4, 128, 136, 256, torch.float16),
+        (12, 4, 16, 512, 512, torch.bfloat16),
+        (24, 8, 2, 512, 768, torch.float16),
+        (9, 3, 128, 512, 664, torch.bfloat16),
+        (12, 4, 16, 512, 512, torch.float16),
+    ],
+)
+def test_reorder_key_value_tp_1d(
+    n_head,
+    n_query_groups,
+    q_len,
+    kv_len,
+    input_pos,
+    dtype,
+):
+    seed = 31415927
+    torch.manual_seed(seed)
+
+    batch_size = 2
+    head_size = 32
+    device = torch.device("cuda", 0)
+
+    config = Config.from_name(
+        "gemma-2-27b",
+        block_size=input_pos + 2 * kv_len,
+        sliding_window_size=None,
+        attention_logit_softcapping=None,
+        n_layer=1,
+        n_query_groups=n_query_groups,
+        n_head=n_head,
+        n_embd=n_head * head_size,
+        intermediate_size=n_head * head_size * 3,
+        rotary_percentage=1.0,
+    )
+    params = KVCacheParams.from_config(
+        config=config,
+        max_batch_size=batch_size,
+        cache_length=kv_len,
+        dtype=dtype,
+    )
+    names = []
+    mha_pairs = []
+    # FlexAttention: Only on GPU
+    # No internal zero-padding of query
+    flexatt_args_no_zp = FlexAttentionArgs(q_lens=[q_len])
+    names.append("flex-att-no-zp")
+    mha_pairs.append(
+        [
+            MultiHeadSelfAttention(
+                config, flexatt_args=flexatt_args_no_zp, sort_if_3d=sort_if_3d
+            )
+            for sort_if_3d in (True, False)
+        ]
+    )
+    # Internal zero-padding of query
+    flexatt_args_zp = FlexAttentionArgs(q_lens=[q_len + 8])
+    names.append("flex-att-zp")
+    mha_pairs.append(
+        [
+            MultiHeadSelfAttention(
+                config, flexatt_args=flexatt_args_zp, sort_if_3d=sort_if_3d
+            )
+            for sort_if_3d in (True, False)
+        ]
+    )
+
+    last_ex = None
+    for name, mhas in zip(names, mha_pairs):
+        # Sample data
+        data = random_args_cache_forward(
+            params,
+            num=kv_len,
+            vocab_size=config.vocab_size,
+            device=device,
+        )
+        end = input_pos + q_len
+        start = end - kv_len
+        token_positions = index_to_3d(
+            torch.randperm(
+                end - start,
+                device=device,
+                dtype=torch.int64,
+            )
+            + start,
+            batch_size,
+            n_query_groups,
+        )
+        outputs = [
+            mha(
+                query=data["query"][:, :, :q_len, :],
+                k_and_v=DefaultKeysAndValues(data["key"], data["value"]),
+                block_idx=0,
+                input_pos=input_pos,
+                token_positions=token_positions,
+            )[0]
+            for mha in mhas
+        ]
+        try:
+            torch.testing.assert_close(outputs[0], outputs[1])
+        except AssertionError as ex:
+            print(f"\n{name}:\n" + str(ex))
+            last_ex = ex
+    if last_ex is not None:
+        raise last_ex

--- a/test/test_flex_attention.py
+++ b/test/test_flex_attention.py
@@ -22,24 +22,22 @@ from keys_values.config import Config
 from litgpt.utils import _RunIf
 
 from keys_values.attention import MultiHeadSelfAttention, DefaultKeysAndValues
+from keys_values.attention_utils import sample_token_positions
 from keys_values.flex_attention import (
     FlexAttentionArgs,
     scaled_dot_product_attention_flexatt,
 )
 from keys_values.kvcache.base import KVCacheParams
-from keys_values.kvcache.test_utils import (
-    random_args_cache_forward,
-    random_index,
-)
+from keys_values.kvcache.test_utils import random_args_cache_forward
 from keys_values.utils import index_to_3d
 
 
 @_RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize(
-    "tp_ndim",
-    (0, 1, 3, None),
+    "tp_ndim, sort_if_3d",
+    list(product((0, 1, 3, None), (False, True))),
 )
-def test_flexatt_working(tp_ndim):
+def test_flexatt_working(tp_ndim, sort_if_3d):
     seed = 31415927
     torch.manual_seed(seed)
 
@@ -114,31 +112,33 @@ def test_flexatt_working(tp_ndim):
             attention_logit_softcapping=None,
             input_pos=0,
             token_positions=None,
+            sort_if_3d=sort_if_3d,
         )
         print(attn_outputs.sum().item())
         # Process chunk
         if tp_ndim == 0:
             token_positions = None
         elif tp_ndim == 1:
-            _ind = random_index(
-                params,
-                start=0,
-                end=cache_length + chunk_size,
-                num=cache_length,
+            _ind = sample_token_positions(
                 batch_size=1,
+                n_query_groups=1,
+                q_len=chunk_size,
+                kv_len=cache_length,
+                input_pos=cache_length,
                 device=device,
-            )
+            ).flatten()
             token_positions = index_to_3d(
-                _ind[0, 0, :],
+                _ind,
                 batch_size,
                 n_query_groups,
             )
         else:
-            token_positions = random_index(
-                params,
-                start=0,
-                end=cache_length + chunk_size,
-                num=cache_length,
+            token_positions = sample_token_positions(
+                batch_size,
+                n_query_groups,
+                chunk_size,
+                cache_length,
+                input_pos=cache_length,
                 device=device,
             )
         print(f"Computing chunk MHA (chunk_size={chunk_size})")
@@ -152,30 +152,28 @@ def test_flexatt_working(tp_ndim):
             attention_logit_softcapping=None,
             input_pos=cache_length,
             token_positions=token_positions,
+            sort_if_3d=sort_if_3d,
         )
         print(attn_outputs.sum().item())
 
 
 @_RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize(
-    "n_head, n_query_groups, q_len, kv_len, dtype, sliding_window_size, attention_logit_softcapping, tp_ndim, atol",
+    "n_head, n_query_groups, q_len, kv_len, dtype, attention_logit_softcapping, atol, tp_ndim",
     [
         a + (b,)
         for a, b in product(
             [
-                (4, 2, 128, 512, torch.float16, None, None, 0.0002),
-                (4, 4, 8, 256, torch.bfloat16, None, None, 0.0008),
-                (8, 4, 32, 128, torch.float16, None, None, 0.0002),
-                (12, 4, 16, 512, torch.bfloat16, None, None, 0.002),
-                (24, 8, 2, 512, torch.float16, None, None, 0.0002),
-                (9, 3, 128, 512, torch.bfloat16, None, None, 0.002),
-                (12, 4, 16, 512, torch.float16, 12, None, 0.0003),
-                (24, 8, 2, 512, torch.bfloat16, 64, None, 0.0008),
-                (9, 3, 128, 512, torch.float16, 96, None, 0.0002),
-                (12, 4, 16, 512, torch.float16, None, 5, 0.0004),
-                (24, 8, 2, 512, torch.bfloat16, None, 2, 0.004),
-                (12, 4, 16, 512, torch.float16, 64, 5, 0.0004),
-                (9, 3, 128, 512, torch.float16, 12, 2, 0.0004),
+                (4, 2, 128, 512, torch.float16, None, 0.0002),
+                (4, 4, 8, 256, torch.bfloat16, None, 0.0008),
+                (8, 4, 32, 128, torch.float16, None, 0.0002),
+                (12, 4, 16, 512, torch.bfloat16, None, 0.002),
+                (24, 8, 2, 512, torch.float16, None, 0.0002),
+                (9, 3, 128, 512, torch.bfloat16, None, 0.002),
+                (12, 4, 16, 512, torch.float16, 5, 0.0004),
+                (24, 8, 2, 512, torch.bfloat16, 2, 0.004),
+                (12, 4, 16, 512, torch.float16, 5, 0.0004),
+                (9, 3, 128, 512, torch.float16, 2, 0.0004),
             ],
             [1, 3],
         )
@@ -187,10 +185,9 @@ def test_comparison(
     q_len,
     kv_len,
     dtype,
-    sliding_window_size,
     attention_logit_softcapping,
-    tp_ndim,
     atol,
+    tp_ndim,
 ):
     seed = 31415927
     torch.manual_seed(seed)
@@ -203,7 +200,7 @@ def test_comparison(
     config = Config.from_name(
         "gemma-2-27b",
         block_size=3 * kv_len,
-        sliding_window_size=sliding_window_size,
+        sliding_window_size=None,
         attention_logit_softcapping=attention_logit_softcapping,
         n_layer=1,
         n_query_groups=n_query_groups,
@@ -245,29 +242,24 @@ def test_comparison(
                 dim=2,
             )
             assert data[chunk][name].shape[2] == kv_len
-        # We need a valid `token_positions` here, which covers
-        # `range(input_pos, input_pos + q_len)`
-        end = input_pos + q_len
-        start = end - kv_len
         if tp_ndim == 1:
-            _ind = random_index(
-                params,
-                start=start,
-                end=end,
-                num=kv_len,
+            _ind = sample_token_positions(
                 batch_size=1,
+                n_query_groups=1,
+                q_len=q_len,
+                kv_len=kv_len,
+                input_pos=input_pos,
                 device=device,
-            )
-            token_positions.append(
-                index_to_3d(_ind[0, 0, :], batch_size, n_query_groups)
-            )
+            ).flatten()
+            token_positions.append(index_to_3d(_ind, batch_size, n_query_groups))
         else:
             token_positions.append(
-                random_index(
-                    params,
-                    start=start,
-                    end=end,
-                    num=kv_len,
+                sample_token_positions(
+                    batch_size,
+                    n_query_groups,
+                    q_len,
+                    kv_len,
+                    input_pos=input_pos,
                     device=device,
                 )
             )

--- a/test/test_sdpa_wrapper.py
+++ b/test/test_sdpa_wrapper.py
@@ -31,8 +31,11 @@ from keys_values.kvcache.test_utils import (
     random_args_cache_forward,
     range_from_args,
 )
-from keys_values.sdpa_wrapper import scaled_dot_product_attention as wrapper_sdpa
-from keys_values.utils import randint_torch
+from keys_values.sdpa_wrapper import (
+    scaled_dot_product_attention as wrapper_sdpa,
+    reorder_key_value,
+)
+from keys_values.utils import randint_torch, index_to_3d
 
 
 @pytest.mark.parametrize(
@@ -234,3 +237,41 @@ def test_wrapper_with_lastrec_cache(device, dtype, tol_kwargs):
             **tol_kwargs,
         )
         input_pos = end
+
+
+def test_reorder_key_value_for_1d_token_positions():
+    seed = 31415927
+    torch.random.manual_seed(seed)
+
+    num_repeat = 50
+    for _ in range(num_repeat):
+        batch_size = randint_torch(1, 4)
+        n_query_groups = randint_torch(1, 8)
+        cache_length = randint_torch(64, 256)
+        head_size = 2 ** randint_torch(4, 7)
+        shape = (batch_size, n_query_groups, cache_length, head_size)
+        key = torch.randn(shape)
+        value = torch.randn(shape)
+        token_positions = index_to_3d(
+            torch.randperm(cache_length),
+            batch_size,
+            n_query_groups,
+        )
+        res_1 = reorder_key_value(
+            key,
+            value,
+            token_positions,
+            input_pos=16,
+            q_len=8,
+            sort_if_3d=True,
+        )
+        res_2 = reorder_key_value(
+            key,
+            value,
+            token_positions.contiguous(),
+            input_pos=16,
+            q_len=8,
+            sort_if_3d=True,
+        )
+        for i in range(2):
+            torch.testing.assert_close(res_1[i], res_2[i])


### PR DESCRIPTION
…ive to sorting if 3D. FlexAttention does not work with sliding_window_size (#69)

This PR is based on a lot of experimentation and testing, see #66. Learnings:

- Exploiting essentially 1D `token_positions` was not done properly. It helps also because `autograd` uses fewer nodes
- FlexAttention cannot support `sliding_window_size` and reordering
- Can avoid sorting all of `token_positions`

Closes #66.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
