### PR TITLE
add max_length in metadata and fix the bug for list output

### DIFF
--- a/keys_values/data/helmet.py
+++ b/keys_values/data/helmet.py
@@ -122,18 +122,30 @@ class Helmet(SequenceLengthFilteredDataModule):
                 metadata = {METADATA_SEQ_LENGTHS_KEY: {}}
             if self.dataset_key not in metadata[METADATA_SEQ_LENGTHS_KEY]:
                 metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key] = {}
-            if self.max_length not in metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key]:
-                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length] = {}
-            if model_name not in metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length]:
-                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][model_name] = {}
+            if (
+                self.max_length
+                not in metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key]
+            ):
+                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][
+                    self.max_length
+                ] = {}
+            if (
+                model_name
+                not in metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][
+                    self.max_length
+                ]
+            ):
+                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][
+                    model_name
+                ] = {}
             if dev_needs_store:
-                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][model_name][
-                    "dev"
-                ] = dev_seq_lengths
+                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][
+                    model_name
+                ]["dev"] = dev_seq_lengths
             if eval_needs_store:
-                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][model_name][
-                    "eval"
-                ] = eval_seq_lengths
+                metadata[METADATA_SEQ_LENGTHS_KEY][self.dataset_key][self.max_length][
+                    model_name
+                ]["eval"] = eval_seq_lengths
             self._store_metadata(metadata)
         return train_data, test_data
 
@@ -180,8 +192,13 @@ class Helmet(SequenceLengthFilteredDataModule):
             else dataset
         )
         _list_output_datasets = {
-            "nq", "trivia_qa", "hotpot_qa", "pop_qa",
-            "narrative_qa", "ruler_mk_needle", "ruler_mk_uuid",
+            "nq",
+            "trivia_qa",
+            "hotpot_qa",
+            "pop_qa",
+            "narrative_qa",
+            "ruler_mk_needle",
+            "ruler_mk_uuid",
         }
         results: RawDatasetType = []
         new_seq_lengths: List[int] = []


### PR DESCRIPTION
This PR fixes two bugs in the HELMET data pipeline and cleans up a debug flag.

## Fix: output field is a list for several Helmet datasets

For datasets such as nq, trivia_qa, hotpot_qa, pop_qa, narrative_qa, ruler_mk_needle, and ruler_mk_uuid, load_rag returns instance["output"] as a list of answers rather than a single string. Passing this list directly to the tokenizer caused a runtime error. The fix applies a deterministic random.choice (seeded per index) to select one answer for these datasets, matching the existing pattern used elsewhere in the codebase.

## Fix: max_length missing from metadata cache key

Sequence-length metadata was keyed by dataset_key → model_name → split, so cached lengths computed for one context-length bucket (e.g. 8k) would be incorrectly reused for another (e.g. 64k). max_length is now included in the hierarchy: dataset_key → max_length → model_name → split.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
