### PR TITLE
Small fixes and additions (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This example runs on a single `Nvidia A 100` GPU with 40 GB of RAM.
 
 ```bash
 cd ${KEYS_VALUES_PATH}
-python3 keys_values/__main__.py finetune_long_lora Qwen/Qwen2.5-0.5B --out_dir /home/ubuntu/out/finetune/longcontext_lora --data LongBenchV2 --data.max_seq_length 100000 --data.metadata_dir /home/ubuntu/out/finetune/longcontext_lora/data --head_model seq_classification_on_logits --precision bf16-true --verbose some --kv_cache.name h2o-default --kv_cache.cache_length 16384 --kv_cache.chunk_size 1024 --train.save_interval 10 --train.micro_batch_size 4 --train.global_batch_size 4 --eval.interval 10
+python3 keys_values/__main__.py finetune_long_lora Qwen/Qwen2.5-0.5B --out_dir /home/ubuntu/out/finetune/longcontext_lora --data LongBenchV2 --data.max_seq_length 100000 --data.metadata_dir /home/ubuntu/out/finetune/longcontext_lora/data --head_model seq_classification_on_logits --precision bf16-true --verbose some --kv_cache.name h2o-default --kv_cache.cache_length 16384 --kv_cache.chunk_size 1024 --train.save_interval 10 --train.micro_batch_size 4 --eval.interval 10
 ```
 
 What is happening here?
@@ -109,12 +109,11 @@ CLI command above like runs training with an effective batch size of 32:
 
 ```bash
 cd ${KEYS_VALUES_PATH}
-python3 keys_values/__main__.py finetune_long_lora Qwen/Qwen2.5-0.5B --out_dir /home/ubuntu/out/finetune/longcontext_lora --devices 8 --data LongBenchV2 --data.max_seq_length 100000 --data.metadata_dir /home/ubuntu/out/finetune/longcontext_lora/data --head_model seq_classification_on_logits --precision bf16-true --verbose some --kv_cache.name h2o-default --kv_cache.cache_length 16384 --kv_cache.chunk_size 1024 --train.save_interval 10 --train.micro_batch_size 4 --train.global_batch_size 32 --eval.interval 10
+python3 keys_values/__main__.py finetune_long_lora Qwen/Qwen2.5-0.5B --out_dir /home/ubuntu/out/finetune/longcontext_lora --devices 8 --data LongBenchV2 --data.max_seq_length 100000 --data.metadata_dir /home/ubuntu/out/finetune/longcontext_lora/data --head_model seq_classification_on_logits --precision bf16-true --verbose some --kv_cache.name h2o-default --kv_cache.cache_length 16384 --kv_cache.chunk_size 1024 --train.save_interval 10 --train.micro_batch_size 4 --eval.interval 10
 ```
 
-Here, `--devices 8 --train.micro_batch_size 4 --train.global_batch_size 32` sets the
-effective batch size to 32, the per-device batch size to 4, and asks to use 8
-devices.
+Here, `--devices 8 --train.micro_batch_size 4` sets `train.global_batch_size`
+to 32, the per-device batch size to 4, and asks to use 8 devices.
 
 ### What's Next?
 
@@ -234,10 +233,9 @@ Basic arguments are:
   - `train.micro_batch_size`: Batch size for individual computations on single
     device.
   - `train.global_batch_size`: Not for `finetune_offload_*`. Batch size used
-    for optimizer updates. Must be  multiple of `train.micro_batch_size`. If
-    `train.global_batch_size == train.micro_batch_size * devices`, this is
-    distributed data parallel. For `finetune_offload_*`, this value is set
-    automatically.
+    for optimizer updates. Must be multiple of `train.micro_batch_size * devices`.
+    Defaults to `train.micro_batch_size * devices`. For `finetune_offload_*`,
+    this value is set automatically.
   - `train.save_interval`: Number of optimizer steps between saving checkpoints.
   - `train.intermed_save_interval`, `train.intermed_save_num`: If these are given,
     additional intermediate checkpoints are stored every `train.intermed_save_interval`

--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
+import math
 from typing import Optional, Tuple, Dict, Any, List, Literal
 
-from litgpt.args import EvalArgs as _EvalArgs, TrainArgs as _TrainArgs
+from litgpt.args import EvalArgs as _EvalArgs
 
 from keys_values.kvcache.factory import KVCacheFactory
 from keys_values.kvcache.consts import split_name, SUPPORTED_QUANTIZERS
@@ -389,9 +390,13 @@ class LoRAARgs:
 
 
 @dataclass
-class TrainArgs(_TrainArgs):
+class TrainArgs:
     """
-    Extends arguments in :class:`litgpt.args.TrainArgs`.
+    Modified training-related arguments in :class:`litgpt.args.TrainArgs`.
+
+    Here, `global_batch_size` does not have a default value. If not given,
+    it should be set to the product of `micro_batch_size` and the number of
+    devices, unless sequential gradient averaging is desired.
 
     Storing intermediate checkpoints: Normal checkpoints are stored whenever
     `state["step_count"] % train.save_interval == 0`. If
@@ -406,11 +411,52 @@ class TrainArgs(_TrainArgs):
         intermed_save_num: See above
     """
 
+    save_interval: Optional[int] = 1000
+    """Number of optimizer steps between saving checkpoints"""
+    log_interval: int = 1
+    """Number of iterations between logging calls"""
+    global_batch_size: Optional[int] = None
+    """Number of samples between optimizer steps across data-parallel ranks"""
+    micro_batch_size: int = 4
+    """Number of samples per data-parallel rank"""
+    lr_warmup_steps: Optional[int] = 100
+    """Number of iterations with learning rate warmup active"""
+    lr_warmup_fraction: Optional[float] = None
+    """The fraction of an epoch to use for learning rate warmup"""
+    epochs: Optional[int] = None
+    """Number of epochs to train on"""
+    # TODO: `pretrain` is the only script using `max_tokens` explicitly. replace it with epoch_size*epochs?
+    max_tokens: Optional[int] = None
+    """Total number of tokens to train on"""
+    max_steps: Optional[int] = None
+    """Limits the number of optimizer steps to run"""
+    max_time: Optional[float] = None
+    """Limits the number of seconds to train for"""
+    max_seq_length: Optional[int] = None
+    """Limits the length of samples"""
+    tie_embeddings: Optional[bool] = None
+    """Whether to tie the embedding weights with the language modeling head weights"""
     intermed_save_interval: Optional[int] = None
     intermed_save_num: Optional[int] = None
 
-    def __post_init__(self):
-        super().__post_init__()
+    def __post_init__(self) -> None:
+        if self.lr_warmup_fraction and self.lr_warmup_steps:
+            raise ValueError(
+                "Can't provide both `--train.lr_warmup_fraction` and `--train.lr_warmup_steps`. Choose one."
+            )
+        if self.lr_warmup_fraction and not (0 <= self.lr_warmup_fraction <= 1):
+            raise ValueError("`--train.lr_warmup_fraction` must be between 0 and 1.")
+
+        if (
+            self.lr_warmup_steps
+            and self.max_steps
+            and (self.lr_warmup_steps >= self.max_steps)
+        ):
+            print(
+                "`--train.lr_warmup_steps` should be less than `--train.max_steps`."
+                f" Got {self.lr_warmup_steps} lr_warmup_steps and {self.max_steps} max_steps.",
+            )
+
         if self.intermed_save_interval is not None:
             if self.intermed_save_interval <= 0:
                 raise ValueError("intermed_save_interval must be positive")
@@ -427,6 +473,36 @@ class TrainArgs(_TrainArgs):
             raise ValueError(
                 "intermed_save_num only needed if intermed_save_interval is given"
             )
+
+    def gradient_accumulation_iters(self, devices: int, num_nodes: int = 1) -> int:
+        """Number of iterations between gradient synchronizations"""
+        gradient_accumulation_iters = (
+            self.batch_size(devices, num_nodes) // self.micro_batch_size
+        )
+        assert gradient_accumulation_iters > 0
+        return gradient_accumulation_iters
+
+    def batch_size(self, devices: int, num_nodes: int = 1) -> int:
+        """Number of samples between optimizer steps per data-parallel rank"""
+        batch_size = self.global_batch_size // (devices * num_nodes)
+        assert batch_size > 0
+        return batch_size
+
+    def warmup_iters(
+        self, devices: int, num_nodes: int, max_iters: int, train_dataloader
+    ) -> int:
+        """Number of iterations to warm up the learning rate."""
+        if self.lr_warmup_fraction:
+            return min(
+                max_iters, math.ceil(self.lr_warmup_fraction * len(train_dataloader))
+            )
+        if self.lr_warmup_steps:
+            return min(
+                max_iters,
+                self.lr_warmup_steps
+                * self.gradient_accumulation_iters(devices, num_nodes),
+            )
+        return 0
 
 
 @dataclass

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -144,8 +144,8 @@ def setup(
     train: TrainArgs = TrainArgs(
         save_interval=50,
         log_interval=1,
-        global_batch_size=16,
-        micro_batch_size=1,
+        global_batch_size=None,
+        micro_batch_size=2,
         lr_warmup_steps=None,
         lr_warmup_fraction=0.15,
         epochs=5,
@@ -159,6 +159,7 @@ def setup(
         max_iters=100,
         initial_validation=None,  # Default set below
         final_validation=True,
+        micro_batch_size=None,
     ),
     optimizer: Optional[OptimizerArgs] = None,
     logger_name: Literal["wandb", "tensorboard", "csv", "mlflow"] = "csv",
@@ -192,6 +193,7 @@ def setup(
     verbose: Optional[str] = None,
     attention_forward_temp_size_gb: Optional[float] = None,
     attention_backward_temp_size_gb: Optional[float] = None,
+    oom_error_recovery: bool = False,
     yarn_rope: bool = True,
     sdpa: SDPAArgs = SDPAArgs(
         flex_attention=True,
@@ -259,6 +261,10 @@ def setup(
         attention_backward_temp_size_gb: Size of GPU memory buffers (in GB) used
             in naive SDPA during backward computations. At present, naive SDPA
             is used in backward if `grad.use_old_cache == True`.
+        oom_error_recovery: If `True`, we try to recover from device out of
+            memory errors by lowering `attention_forward_temp_size_gb`,
+            `attention_backward_temp_size_gb` and trying again.
+            NOTE: This feature does not properly work at the moment!
         yarn_rope: Should YaRN be used to adjust RoPE (position encoding) to the
             sequence length for each batch? Defaults to `True`. If not, RoPE is
             determined by the model configuration, and is static (no dependence
@@ -324,6 +330,7 @@ def setup(
         verbose,
         attention_forward_temp_size_gb,
         attention_backward_temp_size_gb,
+        oom_error_recovery,
         yarn_rope,
         sdpa,
         record_gpu_memory_snapshots,
@@ -361,6 +368,7 @@ def setup_internal(
     verbose: Optional[str],
     attention_forward_temp_size_gb: Optional[float],
     attention_backward_temp_size_gb: Optional[float],
+    oom_error_recovery: bool,
     yarn_rope: bool,
     sdpa: SDPAArgs,
     record_gpu_memory_snapshots: Optional[int],
@@ -407,11 +415,22 @@ def setup_internal(
         )
     else:
         print(str(optimizer))
-    if do_cpu_offload:
-        global_batch_size = train.micro_batch_size * devices
+    global_batch_size = train.micro_batch_size * devices
+    if train.global_batch_size is None:
+        train.global_batch_size = global_batch_size
+    elif do_cpu_offload:
         if train.global_batch_size != global_batch_size:
             print(f"train.global_batch_size not supported, set to {global_batch_size}")
             train.global_batch_size = global_batch_size
+    elif (
+        train.global_batch_size % global_batch_size != 0
+        or train.global_batch_size < global_batch_size
+    ):
+        raise ValueError(
+            f"train.global_batch_size = {train.global_batch_size}, must be "
+            "positive multiple of devices * train.micro_batch_size = "
+            f"{global_batch_size}."
+        )
     if profile_parts is not None and profile_parts not in ("forward", "backward"):
         raise ValueError("profile_parts: Must be 'forward' or 'backward'")
     if size_log_quantiles is not None:
@@ -426,6 +445,11 @@ def setup_internal(
             raise ValueError(
                 f"size_log_quantiles = {size_log_quantiles}, must not have duplicates"
             )
+    if oom_error_recovery:
+        print(
+            "Warning: Device out of memory error recovery does not properly "
+            "work at the moment."
+        )
     # Legacy arguments
     if verbose is None:
         if kv_cache.verbose is not None:
@@ -518,6 +542,7 @@ def setup_internal(
         verbose=verbose,
         attention_forward_temp_size_gb=attention_forward_temp_size_gb,
         attention_backward_temp_size_gb=attention_backward_temp_size_gb,
+        oom_error_recovery=oom_error_recovery,
         yarn_rope=yarn_rope,
         sdpa=sdpa,
         record_gpu_memory_snapshots=record_gpu_memory_snapshots,
@@ -566,6 +591,7 @@ def main(
     verbose: VerbosityLevels,
     attention_forward_temp_size_gb: float,
     attention_backward_temp_size_gb: float,
+    oom_error_recovery: bool,
     yarn_rope: bool,
     sdpa: SDPAArgs,
     record_gpu_memory_snapshots: Optional[RecordGPUMemory],
@@ -667,6 +693,7 @@ def main(
             profile_parts=profile_parts,
             fabric=fabric,
             debug_dont_use_autograd_hooks=debug_dont_use_autograd_hooks,
+            oom_error_recovery=oom_error_recovery,
             **wrap_kwargs,
         )
 
@@ -924,6 +951,7 @@ def wrap_gpt_model(
     offload_num_devices: int = 1,
     fabric: Optional[L.Fabric] = None,
     debug_dont_use_autograd_hooks: bool = False,
+    oom_error_recovery: bool = False,
     model_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Tuple[
     Union[LongContextGradientModel, LongContextInferenceModel],
@@ -976,6 +1004,7 @@ def wrap_gpt_model(
         chunks_per_cell_multiplier=multiplier,
         verbose=verbose,
         tmp_array_limit_gb=tmp_array_limit_gb,
+        oom_error_recovery=oom_error_recovery,
         cache_offloader=cache_offloader,
     )
     if model_kwargs is not None:

--- a/keys_values/head_model.py
+++ b/keys_values/head_model.py
@@ -200,7 +200,13 @@ class CrossEntropyOnLogits(HeadModel):
                 ignore_index=self._ignore_index,
                 reduction="none",
             )
-            return losses.view(*logits.shape[:2]).mean(dim=-1)
+            denom = (
+                (targets != self._ignore_index)
+                .sum(dim=-1)
+                .to(dtype=logits.dtype)
+                .clamp(min=1e-6)
+            )
+            return losses.view(*logits.shape[:2]).sum(dim=-1) / denom
         else:
             return torch.zeros(
                 model_outputs.shape[0],
@@ -251,7 +257,6 @@ class SequenceClassificationOnLogits(HeadModel):
     separate linear head to be trained. On the other hand, predictions are
     more computationally wasteful, because the logits over the whole
     vocabulary are determined.
-
     """
 
     NAME = "seq_classification_on_logits"
@@ -342,7 +347,6 @@ class SequenceClassification(HeadModel):
 
     - "last": Outpyt embedding for final input token
     - "mean": Mean of output embeddings for all tokens
-
     """
 
     NAME = "seq_classification"

--- a/keys_values/kvcache/gradient/main.py
+++ b/keys_values/kvcache/gradient/main.py
@@ -222,6 +222,7 @@ class LongContextGradientModel(LongContextInferenceModel):
         single_tokens_for_targets: bool = False,
         verbose: VerbosityLevels = VerbosityLevels.SOME,
         tmp_array_limit_gb: Optional[TemporaryArrayLimit] = None,
+        oom_error_recovery: bool = False,
         cache_offloader: Optional[KVCacheOffloader] = None,
         set_max_seq_length: bool = True,
         debug_single_cell_per_row: bool = False,
@@ -273,6 +274,8 @@ class LongContextGradientModel(LongContextInferenceModel):
                 information
             tmp_array_limit_gb: Size limit for temporary buffers in device
                 memory, for forward computations
+            oom_error_recovery: See above. If `True`, `tmp_array_limit_gb` must
+                be given.
             set_max_seq_length: If `True`, we set `gpt_model.max_seq_length` to
                 the length of `input_ids` with each call of :meth:`forward`
                 for which `targets is not None`. The value is passed through
@@ -328,11 +331,16 @@ class LongContextGradientModel(LongContextInferenceModel):
             chunks_per_cell_multiplier=chunks_per_cell_multiplier,
             verbose=verbose,
             tmp_array_limit_gb=tmp_array_limit_gb,
+            oom_error_recovery=oom_error_recovery,
             cache_offloader=cache_offloader,
             set_max_seq_length=set_max_seq_length,
             debug_single_cell_per_row=debug_single_cell_per_row,
             debug_intermediates=debug_intermediates,
         )
+        if oom_error_recovery and backward_tmp_array_limit_gb is None:
+            raise ValueError(
+                "backward_tmp_array_limit_gb must be given if oom_error_recovery=True"
+            )
         self.single_tokens_for_targets = single_tokens_for_targets
         if layercp_qname is None:
             layercp_qname = "torch-quantized8"
@@ -602,6 +610,7 @@ class LongContextGradientModel(LongContextInferenceModel):
             chunks_per_cell_multiplier=self.chunks_per_cell_multiplier,
             verbose=self.verbose,
             tmp_array_limit_gb=self._tmp_array_limit_gb,
+            oom_error_recovery=self._oom_error_recovery,
             debug_single_cell_per_row=self._debug_single_cell_per_row,
             debug_intermediates=self.debug_intermediates,
         )
@@ -906,7 +915,7 @@ class LongContextGradientModel(LongContextInferenceModel):
 
         # Call :meth:`_backward_accumulate_gradients_nocheck`. May be done
         # several times with reduced memory limits
-        if self._backward_tmp_array_limit_gb is None:
+        if not self._oom_error_recovery:
             self._backward_accumulate_gradients_nocheck(0)
         else:
             is_done = False

--- a/keys_values/long_context.py
+++ b/keys_values/long_context.py
@@ -486,6 +486,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
         chunks_per_cell_multiplier: float = 1.0,
         verbose: VerbosityLevels = VerbosityLevels.SOME,
         tmp_array_limit_gb: Optional[TemporaryArrayLimit] = None,
+        oom_error_recovery: bool = False,
         cache_offloader: Optional[KVCacheOffloader] = None,
         set_max_seq_length: bool = True,
         debug_single_cell_per_row: bool = False,
@@ -493,11 +494,11 @@ class LongContextInferenceModel(GPTAndHeadModel):
         debug_no_deallocate_buffers: bool = False,
     ):
         """
-        If `tmp_array_limit_gb` is given, it maintains a limit on
-        temporary device memory used in forward computations. Objects
-        such as KV caches in `gpt_model` must keep a reference. We
-        catch out of memory exceptions during forward computations,
-        reduce the limit and try again.
+        If `tmp_array_limit_gb` is given, it maintains a limit on temporary
+        device memory used in forward computations. Objects such as KV caches
+        in `gpt_model` must keep a reference. If `oom_error_recovery == True`,
+        we catch out of memory exceptions during forward computations, reduce
+        the limit and try again.
 
         Args:
             gpt_model: GPT model to train on sequence data. All layers must have
@@ -521,6 +522,8 @@ class LongContextInferenceModel(GPTAndHeadModel):
                 For ``VerbosityLevels.ALL``, we print deep diagnostic
                 information
             tmp_array_limit_gb: See above.
+            oom_error_recovery: See above. If `True`, `tmp_array_limit_gb` must
+                be given.
             cache_offloader: If CPU offloading of KV cache buffers is used,
                 this must be supplied. It maintains the quantization states on
                 the CPU.
@@ -539,7 +542,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
 
         """
         super().__init__(gpt_model, head_model)
-        self._check_args(gpt_model, chunk_size, tmp_array_limit_gb)
+        self._check_args(gpt_model, chunk_size, tmp_array_limit_gb, oom_error_recovery)
         self.config = gpt_model.config
         self.chunk_size = chunk_size
         self.randomize_chunk_sizes = randomize_chunk_sizes
@@ -562,6 +565,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
         self.chunks_per_cell = None
         self.batch_size = None
         self._tmp_array_limit_gb = tmp_array_limit_gb
+        self._oom_error_recovery = oom_error_recovery
         self.cache_offloader = cache_offloader
         self._set_max_seq_length = set_max_seq_length
         self._record_gpu_memory_snapshots = None
@@ -574,9 +578,14 @@ class LongContextInferenceModel(GPTAndHeadModel):
         gpt_model: GPT,
         chunk_size: int,
         tmp_array_limit_gb: Optional[TemporaryArrayLimit],
+        oom_error_recovery: bool,
     ):
         if chunk_size < 1:
             raise ValueError(f"chunk_size = {chunk_size}, must be >= 1")
+        if oom_error_recovery and tmp_array_limit_gb is None:
+            raise ValueError(
+                "tmp_array_limit_gb is required if oom_error_recovery=True"
+            )
         if tmp_array_limit_gb is not None:
             mha = gpt_model.mha
             if mha.tmp_array_limit_gb is None:
@@ -811,7 +820,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
         number of times, see :class:`TemporaryArrayLimit`.
 
         """
-        if self._tmp_array_limit_gb is None:
+        if not self._oom_error_recovery:
             return self._forward_internal_no_check(
                 input_ids,
                 targets,

--- a/keys_values/sdpa_wrapper.py
+++ b/keys_values/sdpa_wrapper.py
@@ -387,3 +387,43 @@ def reorder_buffer_given_extra_info(
         index_scat = kwargs["index_scat"]
         buffer = _reorder(buffer, index_gat, index_scat)
     return buffer
+
+
+def reorder_inverse(
+    buffer: torch.Tensor,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    Inverse of :meth:`reorder_buffer_given_extra_info`.
+
+    """
+    ndim = buffer.ndim
+    if not (3 <= ndim <= 4):
+        raise ValueError("buffer must be 3D or 4D")
+    sort_index = kwargs.get("sort_index")
+    if sort_index is not None:
+        if sort_index.ndim == 1:
+            inv_index = torch.zeros_like(sort_index)
+            inv_index[sort_index] = torch.arange(
+                sort_index.shape[0],
+                dtype=sort_index.dtype,
+                device=sort_index.device,
+            )
+            if ndim == 3:
+                return buffer[:, :, inv_index]
+            else:
+                return buffer[:, :, inv_index, :]
+        else:
+            if ndim == 4:
+                sort_index = expand_index(sort_index, buffer.shape[-1])
+            return (
+                torch.zeros(
+                    (1,) * ndim,
+                    device=buffer.device,
+                    dtype=buffer.dtype,
+                )
+                .expand(*buffer.shape)
+                .scatter(2, sort_index, buffer)
+            )
+    else:
+        raise NotImplementedError("Not implemented for sort_if_3d=False")


### PR DESCRIPTION
- CL argument for OOM error recovery
- Fix in `CrossEntropyOnLogits` (normalization)
- Need not pass CL arg `train.global_batch_size` now (and better checks)
- Inverse of `reorder_key_value`: Will be needed for SDPA returning the attention weights

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
