### PR TITLE
Improving accuracy of FlexAttn baseline for SDPA returning attention …

### DIFF
--- a/keys_values/flex_attention.py
+++ b/keys_values/flex_attention.py
@@ -96,6 +96,7 @@ class FlexAttnManager:
         self,
         kv_len: int,
         device: torch.device,
+        dtype: torch.dtype,
         requires_grad: bool,
         sliding_window_size: Optional[int],
         als_signature: Optional[int],
@@ -122,6 +123,7 @@ class FlexAttnManager:
         self,
         kv_len: int,
         device: torch.device,
+        dtype: torch.dtype,
         requires_grad: bool,
         sliding_window_size: Optional[int],
         attention_logit_softcapping: Optional[float],
@@ -133,6 +135,7 @@ class FlexAttnManager:
         args = self._get_args(
             kv_len,
             device,
+            dtype,
             requires_grad,
             sliding_window_size,
             als_signature,
@@ -196,23 +199,40 @@ class FlexAttnForPrefillManager(FlexAttnManager):
         self,
         kv_len: int,
         device: torch.device,
+        dtype: torch.dtype,
         requires_grad: bool,
         sliding_window_size: Optional[int],
         als_signature: Optional[int],
         **kwargs,
     ) -> tuple:
-        return kv_len, device, requires_grad, sliding_window_size, als_signature
+        return kv_len, device, dtype, requires_grad, sliding_window_size, als_signature
+
+    _ARGS_NAMES = dict(
+        kv_len=0,
+        device=1,
+        dtype=2,
+        requires_grad=3,
+        sliding_window_size=4,
+        als_signature=5,
+    )
+
+    @staticmethod
+    def _from_args(args: tuple, name: str) -> Any:
+        return args[FlexAttnForPrefillManager._ARGS_NAMES[name]]
 
     def _args_to_str(self, *args) -> str:
         parts = [
-            f"kv_len:{args[0]:5d}",
-            f"requires_grad:{int(args[2]):1d}",
-            f"device:{args[1]}",
+            f"kv_len:{self._from_args(args, 'kv_len'):5d}",
+            f"requires_grad:{int(self._from_args(args, 'requires_grad')):1d}",
+            f"device:{self._from_args(args, 'device')}",
+            f"dtype:{self._from_args(args, 'dtype')}",
         ]
-        if args[3] is not None:
-            parts.append(f"sliding_window_size:{args[3]:3d}")
-        if args[4] is not None:
-            parts.append(f"als_signature:{args[4]}")
+        val = self._from_args(args, "sliding_window_size")
+        if val is not None:
+            parts.append(f"sliding_window_size:{val:3d}")
+        val = self._from_args(args, "als_signature")
+        if val is not None:
+            parts.append(f"als_signature:{val}")
         return ",".join(parts)
 
     def _create_block_mask(
@@ -335,6 +355,7 @@ class FlexAttnForChunkManager(FlexAttnManager):
         self,
         kv_len: int,
         device: torch.device,
+        dtype: torch.dtype,
         requires_grad: bool,
         sliding_window_size: Optional[int],
         als_signature: Optional[int],
@@ -353,26 +374,47 @@ class FlexAttnForChunkManager(FlexAttnManager):
             batch_size,
             n_head,
             device,
+            dtype,
             requires_grad,
             sliding_window_size,
             als_signature,
             reverse,
         )
 
+    _ARGS_NAMES = dict(
+        q_len=0,
+        kv_len=1,
+        batch_size=2,
+        n_head=3,
+        device=4,
+        dtype=5,
+        requires_grad=6,
+        sliding_window_size=7,
+        als_signature=8,
+        reverse=9,
+    )
+
+    @staticmethod
+    def _from_args(args: tuple, name: str) -> Any:
+        return args[FlexAttnForChunkManager._ARGS_NAMES[name]]
+
     def _args_to_str(self, *args) -> str:
         parts = [
-            f"q_len:{args[0]:5d}",
-            f"kv_len:{args[1]:5d}",
-            f"batch_size:{args[2]:3d}",
-            f"n_head:{args[3]:3d}",
-            f"requires_grad:{int(args[5]):1d}",
-            f"device:{args[4]}",
+            f"q_len:{self._from_args(args, 'q_len'):5d}",
+            f"kv_len:{self._from_args(args, 'kv_len'):5d}",
+            f"batch_size:{self._from_args(args, 'batch_size'):3d}",
+            f"n_head:{self._from_args(args, 'n_head'):3d}",
+            f"requires_grad:{int(self._from_args(args, 'requires_grad')):1d}",
+            f"device:{self._from_args(args, 'device')}",
+            f"dtype:{self._from_args(args, 'dtype')}",
         ]
-        if args[6] is not None:
-            parts.append(f"sliding_window_size:{args[6]:3d}")
-        if args[7] is not None:
-            parts.append(f"als_signature:{args[7]}")
-        parts.append(f"reverse:{int(args[8]):1d}")
+        val = self._from_args(args, "sliding_window_size")
+        if val is not None:
+            parts.append(f"sliding_window_size:{val:3d}")
+        val = self._from_args(args, "als_signature")
+        if val is not None:
+            parts.append(f"als_signature:{val}")
+        parts.append(f"reverse:{int(self._from_args(args, 'reverse')):1d}")
         return ",".join(parts)
 
     def _create_block_mask(
@@ -414,7 +456,7 @@ class FlexAttnForChunkManager(FlexAttnManager):
         )
 
     def _extra_flex_attention_kwargs(self, args: tuple) -> Dict[str, Any]:
-        requires_grad = args[5]
+        requires_grad = self._from_args(args, "requires_grad")
         if self.forward_return_lse and not requires_grad:
             return {"return_aux": AuxRequest(lse=True)}
         else:
@@ -463,6 +505,7 @@ class FlexAttentionArgs:
         batch_size: int,
         n_head: int,
         device: torch.device,
+        dtype: torch.dtype,
         requires_grad: bool,
         sliding_window_size: Optional[int],
         attention_logit_softcapping: Optional[float],
@@ -481,6 +524,7 @@ class FlexAttentionArgs:
                 self.attn_prefill_manager(
                     kv_len=kv_len,
                     device=device,
+                    dtype=dtype,
                     requires_grad=requires_grad,
                     sliding_window_size=sliding_window_size,
                     attention_logit_softcapping=attention_logit_softcapping,
@@ -493,6 +537,7 @@ class FlexAttentionArgs:
             _attn_fn, extend_kv = self.attn_chunk_manager(
                 kv_len=kv_len,
                 device=device,
+                dtype=dtype,
                 requires_grad=requires_grad,
                 sliding_window_size=sliding_window_size,
                 attention_logit_softcapping=attention_logit_softcapping,
@@ -614,6 +659,7 @@ def scaled_dot_product_attention_flexatt(
         batch_size=batch_size,
         n_head=n_head,
         device=query.device,
+        dtype=query.dtype,
         requires_grad=requires_grad,
         sliding_window_size=sliding_window_size,
         attention_logit_softcapping=attention_logit_softcapping,
@@ -718,6 +764,10 @@ def sdpa_flexatt_with_attn_weights(
     `sliding_window_size` and `attention_logit_softcapping` are not supported.
     And we must have `flexatt_args.forward_return_lse == True`.
 
+    Arguments `query, key, value` are cast to `float32` for the reverse call,
+    since otherwise numerical errors arise which do not happen for other
+    SDPA variants.
+
     Args:
         flexatt_args: Arguments for `flex_attention`. Must have
             `forward_return_lse == True`.
@@ -744,6 +794,7 @@ def sdpa_flexatt_with_attn_weights(
         key,
         value,
     )
+    dtype = query.dtype
     if query.requires_grad or key.requires_grad or value.requires_grad:
         raise ValueError("Cannot be used with autograd")
     if input_pos <= 0:
@@ -780,6 +831,7 @@ def sdpa_flexatt_with_attn_weights(
     attn_fn, extend_kv = flexatt_args.attn_fn(
         q_len=q_len,
         kv_len=kv_len,
+        dtype=dtype,
         reverse=False,
         **attn_kwargs,
     )
@@ -819,12 +871,13 @@ def sdpa_flexatt_with_attn_weights(
     attn_fn, _ = flexatt_args.attn_fn(
         q_len=kv_len,
         kv_len=q_len,
+        dtype=torch.float32,
         reverse=True,
         **attn_kwargs,
     )
     # Multiply by a factor `exp(mean_lse)` here, divide by the same below
     mean_lse = aux.lse.mean(dim=-1, keepdim=True)
-    vtil_vec = torch.exp(-(aux.lse - mean_lse)).to(dtype=query.dtype)
+    vtil_vec = torch.exp(-(aux.lse - mean_lse))
     if q_len_tr > q_len:
         vtil_vec[:, :, : (q_len_tr - q_len)] = 0.0
     value_tilde = torch.cat(
@@ -832,12 +885,15 @@ def sdpa_flexatt_with_attn_weights(
             vtil_vec.unsqueeze(-1),
             torch.zeros(
                 (1, 1, 1, 1),
-                dtype=query.dtype,
+                dtype=torch.float32,
                 device=query.device,
             ).expand(batch_size, n_head, q_len_tr, MIN_HEAD_DIM - 1),
         ),
         dim=-1,
     )
+    # Cast for better accuracy
+    query = query.to(dtype=torch.float32)
+    key = key.to(dtype=torch.float32)
     output2, aux = attn_fn(
         query=key,
         key=query,
@@ -845,9 +901,7 @@ def sdpa_flexatt_with_attn_weights(
         scale=None,
         enable_gqa=False,
     )
-    attn_weights = output2[:, :, :, 0].to(dtype=torch.float32) * torch.exp(
-        aux.lse - mean_lse
-    )
+    attn_weights = output2[:, :, :, 0] * torch.exp(aux.lse - mean_lse)
     if n_query_groups < n_head:
         # Undo `repeat_interleave`
         attn_weights = torch.mean(

--- a/test/test_attn_weights.py
+++ b/test/test_attn_weights.py
@@ -17,6 +17,8 @@ import math
 import torch
 import pytest
 
+from litgpt.utils import _RunIf
+
 from keys_values.attention import (
     scaled_dot_product_attention_in_blocks,
     DefaultKeysAndValues,
@@ -110,6 +112,7 @@ def eager_weights(query, key, scale, input_pos, token_positions):
     return attn_weights
 
 
+@_RunIf(min_cuda_gpus=1)
 @torch.inference_mode()
 def test_small_comparison():
     torch.manual_seed(42)
@@ -178,6 +181,7 @@ def test_small_comparison():
             assert num_match == keep_k
 
 
+@_RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize(
     "q_len, kv_len, input_pos, keep_ratio, description",
     [

--- a/test/test_attn_weights.py
+++ b/test/test_attn_weights.py
@@ -1,0 +1,240 @@
+# Original Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+# Modification Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import math
+
+import torch
+import pytest
+
+from keys_values.attention import (
+    scaled_dot_product_attention_in_blocks,
+    DefaultKeysAndValues,
+)
+from keys_values.flex_attention import (
+    sdpa_flexatt_with_attn_weights,
+    FlexAttentionArgs,
+)
+from keys_values.utils import repeat_interleave, index_to_3d
+
+
+def pytorch_reference_weights(
+    query,
+    key,
+    scale,
+    input_pos,
+    token_positions,
+):
+    """Ground truth: full matmul + softmax + causal mask + sum.
+
+    Args:
+        query: [batch, n_head, q_len, head_dim]
+        key: [batch, n_kv_heads, kv_len, head_dim]
+        scale: softmax scale factor
+        input_pos: starting query position
+        token_positions: [batch, n_kv_heads, kv_len] int positions
+        n_kv_heads, group_size: GQA parameters
+
+    Returns:
+        W: [batch, n_kv_heads, kv_len] float32 attention weight sums
+    """
+    batch, n_head, q_len, hd = query.shape
+    _, n_kv_heads, kv_len, _ = key.shape
+    q_per_kv = n_head // n_kv_heads
+    Q_4d = query.float()
+    K_exp = repeat_interleave(key.float(), n_head)
+
+    # Scores: [batch, n_head, q_len, kv_len]
+    scores = torch.matmul(Q_4d, K_exp.transpose(-1, -2)) * scale
+
+    # Causal mask
+    q_positions = torch.arange(q_len, device=query.device) + input_pos  # [q_len]
+    # token_positions: [batch, n_kv_heads, kv_len] -> expand to [batch, n_head, kv_len]
+    tp_exp = repeat_interleave(token_positions, n_head)
+
+    # mask[b, h, q, k] = True if kv_pos <= query_pos
+    mask = tp_exp[:, :, None, :] <= q_positions[None, None, :, None]
+    scores.masked_fill_(~mask, float("-inf"))
+
+    # Softmax + sum
+    weights = torch.softmax(scores, dim=-1)  # [B, H, Q, KV]
+    # Sum over queries, then group heads -> [B, Hkv, KV]
+    if q_per_kv > 1:
+        weights = (
+            weights.view(batch, n_kv_heads, q_per_kv, q_len, kv_len).sum(dim=(2, 3))
+            / q_per_kv
+        )
+    else:
+        weights = weights.sum(dim=2)
+    return weights
+
+
+def flexatt_weights(query, key, scale, input_pos, token_positions):
+    flexatt_args = FlexAttentionArgs(
+        forward_return_lse=True,
+        extend_kv=False,
+    )
+    _, attn_weights = sdpa_flexatt_with_attn_weights(
+        flexatt_args=flexatt_args,
+        query=query,
+        key=key,
+        value=key,  # does not matter
+        scale_factor=scale,
+        attention_logit_softcapping=None,
+        input_pos=input_pos,
+        token_positions=token_positions,
+    )
+    return attn_weights
+
+
+def eager_weights(query, key, scale, input_pos, token_positions):
+    _, attn_weights = scaled_dot_product_attention_in_blocks(
+        query=query,
+        k_and_v=DefaultKeysAndValues(key, key),
+        scale_factor=scale,
+        return_attn_weights=True,
+        input_pos=input_pos,
+        token_positions=token_positions,
+        sliding_window_size=None,
+    )
+    return attn_weights
+
+
+@torch.inference_mode()
+def test_small_comparison():
+    torch.manual_seed(42)
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Qwen3-4B config
+    batch_size = 1
+    q_len = 16
+    n_head = 32
+    n_kv_heads = 8
+    hd = 128
+    kv_len = 64
+    input_pos = 48  # simulates non-prefill: query starts at pos 48
+    scale = 1.0 / math.sqrt(hd)
+
+    for tp_contiguous in (True, False):
+        if tp_contiguous:
+            print("\nTest for contiguous token_positions")
+            # Contiguous token positions: 0..kv_len-1
+            token_positions = index_to_3d(
+                torch.arange(kv_len, device=device, dtype=torch.int32),
+                batch_size,
+                n_kv_heads,
+            )
+            kv_len2 = kv_len
+        else:
+            print("\nTest for non-contiguous token_positions")
+            kept_positions = torch.tensor(
+                [0, 2, 5, 8, 10, 15, 20, 25, 30, 35, 40, 45, 47] + list(range(48, 64)),
+                device=device,
+                dtype=torch.int32,
+            )
+            kv_len2 = len(kept_positions)
+            token_positions = index_to_3d(
+                kept_positions,
+                batch_size,
+                n_kv_heads,
+            )
+
+        kwargs = dict(device=device, dtype=dtype)
+        query = torch.randn(batch_size, n_head, q_len, hd, **kwargs)
+        key = torch.randn(batch_size, n_kv_heads, kv_len2, hd, **kwargs)
+
+        # Different variants
+        attn_weights = [
+            func(query, key, scale, input_pos, token_positions)
+            for func in (pytorch_reference_weights, eager_weights, flexatt_weights)
+        ]
+
+        # Compare attn weights
+        print("Comparing summed attention weights:")
+        for ind, name in ((1, "eager"), (2, "FlexAttention")):
+            print(f"PyTorch reference vs {name}:")
+            torch.testing.assert_close(attn_weights[0], attn_weights[ind])
+
+        # Check eviction decisions: which top-K entries differ?
+        keep_ratio = 0.5
+        keep_k = int(kv_len2 * keep_ratio)
+        print(f"Comparing eviction decisions: Keep {keep_k} of {kv_len2}:")
+        topk_ref = attn_weights[0][0, 0, :].topk(keep_k).indices.sort().values
+        for ind, name in ((1, "eager"), (2, "FlexAttention")):
+            topk_comp = attn_weights[ind][0, 0, :].topk(keep_k).indices.sort().values
+            num_match = sum(topk_comp == topk_ref).item()
+            print(f"PyTorch reference vs {name}: {num_match} matches")
+            assert num_match == keep_k
+
+
+@pytest.mark.parametrize(
+    "q_len, kv_len, input_pos, keep_ratio, description",
+    [
+        (16, 256, 240, 0.5, "kv_len=256, keep 50%"),
+        (16, 512, 496, 0.5, "kv_len=512, keep 50%"),
+        (16, 1024, 1008, 0.5, "kv_len=1024, keep 50%"),
+        (16, 2048, 2032, 0.5, "kv_len=2048, keep 50%"),
+        (16, 1024, 1008, 0.25, "kv_len=1024, keep 25% (aggressive eviction)"),
+        (16, 1024, 1008, 0.75, "kv_len=1024, keep 75% (mild eviction)"),
+    ],
+)
+@torch.inference_mode()
+def test_larger_comparison(q_len, kv_len, input_pos, keep_ratio, description):
+    torch.manual_seed(42 + kv_len)
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Qwen3-4B config
+    n_head = 32
+    n_kv_heads = 8
+    hd = 128
+    scale = 1.0 / math.sqrt(hd)
+    batch_size = 1
+
+    token_positions = index_to_3d(
+        torch.arange(kv_len, device=device, dtype=torch.int32),
+        batch_size,
+        n_kv_heads,
+    )
+    kwargs = dict(device=device, dtype=dtype)
+    query = torch.randn(batch_size, n_head, q_len, hd, **kwargs)
+    key = torch.randn(batch_size, n_kv_heads, kv_len, hd, **kwargs)
+
+    # Different variants
+    attn_weights = [
+        func(query, key, scale, input_pos, token_positions)
+        for func in (pytorch_reference_weights, eager_weights, flexatt_weights)
+    ]
+
+    # Compare attn weights
+    print(f"\n{description}\nComparing summed attention weights:")
+    for ind, name in ((1, "eager"), (2, "FlexAttention")):
+        print(f"PyTorch reference vs {name}:")
+        torch.testing.assert_close(attn_weights[0], attn_weights[ind])
+
+    # Check eviction decisions: which top-K entries differ?
+    keep_k = int(kv_len * keep_ratio)
+    print(f"Comparing eviction decisions: Keep {keep_k} of {kv_len}:")
+    # Check all kv heads, not just head 0
+    mismatches = [0, 0]
+    for b in range(batch_size):
+        for h in range(n_kv_heads):
+            topk_ref = set(attn_weights[0][b, h].topk(keep_k).indices.tolist())
+            for ind in range(1, 3):
+                topk_comp = set(attn_weights[ind][b, h].topk(keep_k).indices.tolist())
+                if topk_ref != topk_comp:
+                    mismatches[ind - 1] += 1
+    for name, num_mis in zip(("eager", "FlexAttention"), mismatches):
+        print(f"PyTorch reference vs {name}: {num_mis} mismatches")
+    assert sum(mismatches) == 0


### PR DESCRIPTION
…weights

The FlexAttn baseline was not accurate enough to provide the same eviction decisions as eager SDPA. This PR fixes that. We run the second (reverse) FlexAttn call with `float32` arguments. This renders inference alone a bit slower (up to 15%).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
