### PR TITLE
LongContextInferenceModel.forward returns logits for one token if tar…

### DIFF
--- a/keys_values/generate/base.py
+++ b/keys_values/generate/base.py
@@ -153,10 +153,13 @@ def generate_fn(
     # Prompt processing. This is dealt with by the long context inference
     # model. Processing is done in chunks, the first one being as long as
     # KV caches permit, subsequent ones (if any) chosen by the model.
-    # We need the logits for the final chunk in order to generate the
-    # first token below. Chunk size does not matter, just must be nonzero.
+    # We need the logits for the final position in order to generate the
+    # first token below.
     gpt_model = model.gpt_model
-    logits_final_chunk = model(prompt.unsqueeze(0), targets=None)
+    logits_final_position = model(prompt.unsqueeze(0), targets=None)
+    assert logits_final_position.ndim == 3 and logits_final_position.shape[1] == 1, (
+        logits_final_position.shape,
+    )
 
     # Generation loop: One token per iteration
     tokens = []
@@ -168,8 +171,8 @@ def generate_fn(
         if token is None:
             # First token sampled from the final logits output for prompt
             # processing
-            token = sample(logits_final_chunk, **sample_kwargs).to(dtype=torch.int64)
-            logits_final_chunk = None
+            token = sample(logits_final_position, **sample_kwargs).to(dtype=torch.int64)
+            logits_final_position = None
         else:
             token = next_token(
                 gpt_model=gpt_model,
@@ -277,7 +280,10 @@ def batched_generate_fn(
     # We need the logits for the final chunk in order to generate the
     # first token below. Chunk size does not matter, just must be nonzero.
     gpt_model = model.gpt_model
-    logits_final_chunk = model(prompts, targets=None)
+    logits_final_position = model(prompts, targets=None)
+    assert logits_final_position.ndim == 3 and logits_final_position.shape[1] == 1, (
+        logits_final_position.shape,
+    )
 
     stop_progresses = [
         [0] * len(stop_tokens) for _ in range(batch_size)
@@ -290,8 +296,8 @@ def batched_generate_fn(
     tokens = None
     for current_idx in range(max_returned_tokens - max_prompt_size):
         if current_idx == 0:
-            tokens = batched_sample(logits_final_chunk[:, -1:], kwargs=sample_args)
-            logits_final_chunk = None
+            tokens = batched_sample(logits_final_position, kwargs=sample_args)
+            logits_final_position = None
         else:
             tokens = batched_next_token(
                 gpt_model=gpt_model,

--- a/keys_values/kvcache/gradient/main.py
+++ b/keys_values/kvcache/gradient/main.py
@@ -476,8 +476,8 @@ class LongContextGradientModel(LongContextInferenceModel):
             for which :meth:`backward` is overwritten, and of shape `(1,)`.
             In evaluation mode, we return loss values for batch dimension,
             shape `(batch_size,)`, or if `targets is None`, we return logits
-            for the final chunk, shape `(batch_size, chunk_size,
-            config.padded_vocab_size)`.
+            for the final token position, shape
+            `(batch_size, 1, config.padded_vocab_size)`.
 
         """
         self._check_status("init")

--- a/keys_values/kvcache/quant_buffers.py
+++ b/keys_values/kvcache/quant_buffers.py
@@ -59,7 +59,6 @@ class QuantizedKVCacheBuffers(KVCacheBuffers):
     Note that :meth:`deallocate` only deallocates `quantizer_k`, `quantizer_v`,
     but not `dequant_buffers`. This is because typically, several KV caches
     share the same `dequant_buffers`. It remains allocated.
-
     """
 
     def __init__(
@@ -391,7 +390,6 @@ class DequantizedKVCacheBuffers:
     just not have any. In our case, `self._quantized_cache` is not even set
     in :meth:``__init__`, but only in :meth:`set_quantized_cache`, but even
     this leads to registration and infinite loops.
-
     """
 
     def __init__(
@@ -407,7 +405,6 @@ class DequantizedKVCacheBuffers:
         self.cache_length = cache_length
         self.head_size = params.head_size
         self.dtype = params.dtype
-        self.current_length = None
         self.k_buff = None
         self.v_buff = None
         self._quantized_cache = None
@@ -451,7 +448,6 @@ class DequantizedKVCacheBuffers:
             self.v_buff = torch.zeros(shape, device=device, dtype=self.dtype)
 
     def reset(self):
-        self.current_length = 0
         self._needs_write_back = False
 
     def deallocate(self):
@@ -538,22 +534,26 @@ class DequantizedKVCacheBuffers:
             )
 
     @property
+    def current_length(self) -> Optional[int]:
+        return (
+            None
+            if self._quantized_cache is None
+            else self._quantized_cache.current_length
+        )
+
+    @property
     def eff_cache_length(self) -> int:
-        cache = self._quantized_cache
-        return self.cache_length if cache is None else cache.cache_length
+        return (
+            self.cache_length
+            if self._quantized_cache is None
+            else self._quantized_cache.cache_length
+        )
 
     @property
     def batch_size(self) -> Optional[int]:
-        """
-        Returns:
-            Current effective batch size of the associated quantized
-            cache buffer
-
-        """
-        if self._quantized_cache is not None:
-            return self._quantized_cache.batch_size
-        else:
-            return None
+        return (
+            None if self._quantized_cache is None else self._quantized_cache.batch_size
+        )
 
     # Copied from `DefaultKVCacheBuffers.get_slots`
     def get_slots(
@@ -633,33 +633,21 @@ class DequantizedKVCacheBuffers:
         key: torch.Tensor,
         value: torch.Tensor,
     ) -> KeysAndValues:
-        num = key.shape[2]
-        self.current_length = min(self.eff_cache_length, self.current_length + num)
-        return self._forward(positions, key, value)
-
-    def _forward(
-        self,
-        positions: PositionsType,
-        key: torch.Tensor,
-        value: torch.Tensor,
-    ) -> KeysAndValues:
-        # check_for_nan(key, "DequantizedKVCacheBuffers._forward", "key")
-        # check_for_nan(value, "DequantizedKVCacheBuffers._forward", "value")
         self.set_slots(positions, key, value)
         return DequantizedBufferKeysAndValues(self)
 
     def get_keys_values(self) -> Optional[KeysAndValues]:
-        if self.batch_size is None or self.current_length is None:
-            return None
-        else:
-            return DequantizedBufferKeysAndValues(self)
+        return (
+            None
+            if self._quantized_cache is None
+            else DequantizedBufferKeysAndValues(self)
+        )
 
     # Copied from `KVCacheBuffers.prefill`:
     def prefill(self, key: torch.Tensor, value: torch.Tensor):
         # Ensure that buffers are allocated:
         self._allocate_buffers(key.device, key.dtype)
         self._check_quantized_cache()
-        self.current_length = self._check_prefill(key, value)
         self._prefill(key, value)
 
     # Copied from `KVCacheBuffers._check_prefill`:
@@ -825,7 +813,7 @@ class DequantizedBufferKeysAndValues(KeysAndValues):
                 "buffers must have associated cache. Use 'set_quantized_cache' first"
             )
 
-    def keys(self) -> torch.Tensor:
+    def _check(self) -> Tuple[int, int]:
         if not (self._assoc_quant_buffers is self._buffers._quantized_cache):
             raise IndexError("buffers has been associated with different cache")
         current_length = self._buffers.current_length
@@ -834,17 +822,14 @@ class DequantizedBufferKeysAndValues(KeysAndValues):
             raise IndexError("Associated buffer still has undefined batch size")
         if not self._buffers.buffers_are_allocated:
             raise IndexError("Associated buffer is not allocated")
+        return current_length, batch_size
+
+    def keys(self) -> torch.Tensor:
+        current_length, batch_size = self._check()
         return self._buffers.k_buff[:batch_size, :, :current_length, :]
 
     def values(self) -> torch.Tensor:
-        if not (self._assoc_quant_buffers is self._buffers._quantized_cache):
-            raise IndexError("buffers has been associated with different cache")
-        current_length = self._buffers.current_length
-        batch_size = self._buffers.batch_size
-        if batch_size is None:
-            raise IndexError("Associated buffer still has undefined batch size")
-        if not self._buffers.buffers_are_allocated:
-            raise IndexError("Associated buffer is not allocated")
+        current_length, batch_size = self._check()
         return self._buffers.v_buff[:batch_size, :, :current_length, :]
 
 

--- a/keys_values/long_context.py
+++ b/keys_values/long_context.py
@@ -627,8 +627,8 @@ class LongContextInferenceModel(GPTAndHeadModel):
             by `head_model` (must be given). The loss value is returned.
             The KV caches are reset, their buffers are deallocated.
         * `targets` not given: Process `input_ids`. Return logits for the
-            final chunk being processed. The KV caches are not reset, as the
-            model is to be used for token generations.
+            final token position being processed. The KV caches are not reset,
+            as the model is to be used for token generations.
 
         Args:
             input_ids: Batch of full input token sequences
@@ -639,8 +639,8 @@ class LongContextInferenceModel(GPTAndHeadModel):
 
         Returns:
             Loss values, shape `(batch_size,)`. If `targets` are not given,
-            we return the logits for the final chunk, shape
-            `(batch_size, chunk_size, config.padded_vocab_size)`.
+            we return the logits for the final token position, shape
+            `(batch_size, 1, config.padded_vocab_size)`.
 
         """
         if self.head_model is None and targets is not None:
@@ -874,7 +874,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
             )
         else:
             weight_per_chunk = None
-        logits_final_chunk = None  # Only if no loss is computed
+        logits_final_position = None  # Only if no loss is computed
         # Need grouping of chunks into cells, for outermost loop
         chunks_for_cells = get_chunks_for_cells(
             self.chunks_per_cell,
@@ -954,7 +954,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
                         new_embed_parts.append(y)
                         if not compute_loss:
                             # We need the final layer output for the last chunk
-                            logits_final_chunk = y.detach()
+                            logits_final_position = y[:, -1:, :].detach()
                     if self._do_checkpoint_layer_input() and torch.cuda.is_available():
                         # `_checkpoint_layer_input` called above transfers
                         # `embeddings` to CPU. For this not to lead to
@@ -1023,9 +1023,11 @@ class LongContextInferenceModel(GPTAndHeadModel):
                                 rel_end,
                             )
                 else:
-                    # `logits_final_chunk` has final layer outputs for last
-                    # chunk. Map to logits
-                    logits_final_chunk = self.gpt_model.lm_head(logits_final_chunk)
+                    # `logits_final_position` has final layer outputs for last
+                    # position. Map to logits
+                    logits_final_position = self.gpt_model.lm_head(
+                        logits_final_position
+                    )
                 if self._do_checkpoint_layer_input() and torch.cuda.is_available():
                     # `_checkpoint_layer_input` called above transfers
                     # `embeddings` to CPU. For this not to lead to
@@ -1042,7 +1044,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
             if self.verbose is not VerbosityLevels.NONE:
                 print("\nDeallocate KV cache buffers")
             deallocate_kv_cache_buffers_of_model(self.gpt_model)
-        return loss_full if compute_loss else logits_final_chunk
+        return loss_full if compute_loss else logits_final_position
 
     def _forward_only(
         self,
@@ -1057,7 +1059,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
             print(
                 f"\nForward pass over {len(self.chunk_sizes)} chunks, grouped into {len(self.chunks_per_cell)} cells (inference mode)"
             )
-        loss_full = self._forward_internal(input_ids, targets, scale_factor)
+        result = self._forward_internal(input_ids, targets, scale_factor)
         if not (targets is None or self._debug_no_deallocate_buffers):
             self.clear()
-        return loss_full
+        return result


### PR DESCRIPTION
…gets is None. Fix current_length bug

Two fixes:
* Generation on seqs shorter than cache length used lots of memory: `LongContextInferenceModel.forward` returns logits for final token position only, not for final chunk (which can be large)
* Error involving `current_length`: `DequantizedKVCacheBuffers` has no own `current_length`, but takes that off associated quant buffer

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
