### PR TITLE
New defaults for LoRAArgs: More expensive than in LitGPT. And revert …

### DIFF
--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -352,8 +352,15 @@ class OptimizerArgs:
 
 
 @dataclass
-class LoRAARgs:
+class LoRAArgs:
     """Command line arguments for LoRA fine-tuning
+
+    The defaults here are more expensive than those in `LitGPT`. We follow
+    recommendations given in
+
+    Huang and Balestriero
+    ALLoRA: Adaptive Learning Rate Mitigates LoRA Fatal Flaws
+    https://arxiv.org/abs/2410.09692
 
     With `kind`, a number of variants of LoRA can be chosen:
 
@@ -380,15 +387,15 @@ class LoRAARgs:
         kind: See above. Defaults to "default".
     """
 
-    r: int = 8
+    r: int = 16
     alpha: int = 16
     dropout: float = 0
     query: bool = True
-    key: bool = False
+    key: bool = True
     value: bool = True
-    projection: bool = False
-    mlp: bool = False
-    head: bool = False
+    projection: bool = True
+    mlp: bool = True
+    head: bool = True
     kind: Literal["default", "rms_norm", "dora"] = "default"
 
 

--- a/keys_values/finetune/longcon_offload_lora.py
+++ b/keys_values/finetune/longcon_offload_lora.py
@@ -22,7 +22,7 @@ from keys_values.finetune.args import (
     EvalArgs,
     GradientArgs,
     KVCacheArgs,
-    LoRAARgs,
+    LoRAArgs,
     OptimizerArgs,
     SDPAArgs,
 )
@@ -51,7 +51,7 @@ def setup(
         intermed_save_interval=None,
         intermed_save_num=None,
     ),
-    lora: LoRAARgs = LoRAARgs(
+    lora: LoRAArgs = LoRAArgs(
         r=8,
         alpha=16,
         dropout=0,

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -65,7 +65,7 @@ from keys_values.finetune.args import (
     KVCacheArgs,
     OptimizerArgs,
     SDPAArgs,
-    LoRAARgs,
+    LoRAArgs,
 )
 from keys_values.finetune.batch_transform import (
     BatchTransformFactory,
@@ -360,7 +360,7 @@ def setup_internal(
     resume: Union[bool, Literal["auto"], Path],
     data: Optional[DataModule],
     train: TrainArgs,
-    lora: Optional[LoRAARgs],
+    lora: Optional[LoRAArgs],
     eval: EvalArgs,
     optimizer: Optional[OptimizerArgs],
     logger_name: Literal["wandb", "tensorboard", "csv", "mlflow"],

--- a/keys_values/finetune/longcontext_lora.py
+++ b/keys_values/finetune/longcontext_lora.py
@@ -22,7 +22,7 @@ from keys_values.finetune.args import (
     EvalArgs,
     GradientArgs,
     KVCacheArgs,
-    LoRAARgs,
+    LoRAArgs,
     OptimizerArgs,
     SDPAArgs,
 )
@@ -52,7 +52,7 @@ def setup(
         intermed_save_interval=None,
         intermed_save_num=None,
     ),
-    lora: LoRAARgs = LoRAARgs(
+    lora: LoRAArgs = LoRAArgs(
         r=8,
         alpha=16,
         dropout=0,

--- a/keys_values/lora_utils.py
+++ b/keys_values/lora_utils.py
@@ -184,7 +184,7 @@ class LoRAQKVLinear(BaseLoRAQKVLinear):
         lora_dropout: float = 0.0,
         enable_lora: Union[bool, Tuple[bool, bool, bool]] = False,
         use_rms_norm: bool = False,
-        **kwargs: Any,
+        **kwargs,
     ):
         """LoRA wrapper around linear class that is used for calculation of q, k and v matrices.
 
@@ -314,21 +314,23 @@ class LoRAQKVLinear(BaseLoRAQKVLinear):
 
     @property
     def lora_ind(self) -> torch.Tensor:
-        """
-        Created with each call. If we buffer this, then use the same model first
-        for inference, then for training, we get this error:
+        """Lazily compute and cache LoRA indices as a non-persistent buffer for FSDP meta-device compatibility.
 
-        RuntimeError: Inference tensors cannot be saved for backward. Please do not use Tensors created in inference mode in computation tracked by autograd. To work around this, you can make a clone to get a normal tensor and use it in autograd, or use `torch.no_grad()` instead of `torch.inference_mode()`.
+        Returns a clone so that inference-mode tensors are never passed into autograd.
         """
         # Indices are needed to properly pad weight updates with zeros.
-        off = 0
-        lora_ind = []
-        for enable, size in zip(self.enable_lora, self._all_qkv_shapes):
-            if enable:
-                lora_ind.extend(range(off, off + size))
-            off += size
-        assert len(lora_ind) == sum(self.qkv_shapes)  # Sanity check
-        return torch.tensor(lora_ind, device=self.linear.weight.device)
+        if not hasattr(self, "_lora_ind"):
+            off = 0
+            kwargs = dict(device=self.linear.weight.device, dtype=torch.int64)
+            parts = []
+            for enable, size in zip(self.enable_lora, self._all_qkv_shapes):
+                if enable:
+                    parts.append(torch.arange(off, off + size, **kwargs))
+                off += size
+            lora_ind = torch.cat(parts)
+            assert lora_ind.numel() == sum(self.qkv_shapes)  # Sanity check
+            self.register_buffer("_lora_ind", lora_ind, persistent=False)
+        return self._lora_ind.clone()
 
     def reset_parameters(self):
         super().reset_parameters()

--- a/test/test_lora.py
+++ b/test/test_lora.py
@@ -1041,6 +1041,43 @@ def test_lora_model_fsdp_init():
                 ), f"Attribute `{attr_name}` isn't materialized."
 
 
+def test_zero_pad_cpu_and_mocked_mps():
+    head_size = 64
+    n_head = 12
+    n_query_groups = 3
+    in_features = 128
+    q_size = head_size * n_head
+    kv_size = head_size * n_query_groups
+    enable_lora = (True, False, True)
+    r = 4
+
+    model = LoRAQKVLinear(
+        in_features=in_features,
+        head_size=head_size,
+        n_head=n_head,
+        n_query_groups=n_query_groups,
+        r=r,
+        enable_lora=enable_lora,
+    )
+
+    batch_size = 64
+    seq_len = 64
+    # embed_dim = sum of enabled qkv shapes: Q (q_size) + V (kv_size)
+    embed_dim = q_size + kv_size
+    x = torch.randn(batch_size, seq_len, embed_dim)
+
+    result_cpu = model.zero_pad(x)
+
+    with mock.patch("torch.backends.mps.is_available", return_value=True):
+        with mock.patch("torch.Tensor.device", new_callable=mock.PropertyMock) as mock_device:
+            mock_device.return_value = torch.device("mps")
+
+            result_mps = model.zero_pad(x)
+
+            assert result_cpu.shape == result_mps.shape, "Shape mismatch between CPU and MPS"
+            assert torch.allclose(result_cpu, result_mps), "Tensor values mismatch between CPU and MPS"
+
+
 def test_load_legacy_state_dict():
     """Check that a legacy state dict (with an interleaved placement in QKV matrix) can be loaded into a model with CausalSelfAttention layers."""
     config = Config(

--- a/test/test_lora.py
+++ b/test/test_lora.py
@@ -1069,13 +1069,19 @@ def test_zero_pad_cpu_and_mocked_mps():
     result_cpu = model.zero_pad(x)
 
     with mock.patch("torch.backends.mps.is_available", return_value=True):
-        with mock.patch("torch.Tensor.device", new_callable=mock.PropertyMock) as mock_device:
+        with mock.patch(
+            "torch.Tensor.device", new_callable=mock.PropertyMock
+        ) as mock_device:
             mock_device.return_value = torch.device("mps")
 
             result_mps = model.zero_pad(x)
 
-            assert result_cpu.shape == result_mps.shape, "Shape mismatch between CPU and MPS"
-            assert torch.allclose(result_cpu, result_mps), "Tensor values mismatch between CPU and MPS"
+            assert (
+                result_cpu.shape == result_mps.shape
+            ), "Shape mismatch between CPU and MPS"
+            assert torch.allclose(
+                result_cpu, result_mps
+            ), "Tensor values mismatch between CPU and MPS"
 
 
 def test_load_legacy_state_dict():


### PR DESCRIPTION
…change of LoRAQKVLinear.lora_ind

* Existing defaults in `LitGPT` are not aligned with latest LoRA research
* Revert earlier change in line with `LitGPT`
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
