### PR TITLE
Implement own DDP used without CPU offloading (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ pip install --upgrade pip
 pip install torch==2.10.0 torchmetrics==1.8.2 torchvision==0.25.0
 echo "torch==2.10.0" >constraints.txt
 pip install flashinfer-python==0.6.7 -c constraints.txt
+rm constraints.txt
 pip install 'litgpt[all,test,extra]'
 cd keys_values
 pip install -e .

--- a/docs/launch_instance.md
+++ b/docs/launch_instance.md
@@ -17,7 +17,7 @@ ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-35-85-224-176.us-west-2.com
 
 ### Instance `P4Research2`
 
-* Instance ID: `??`
+* Instance ID: `i-01dee00f42a643ea7`
 * File system ID: `fs-0186b686e7dffc35b`
 * VPC: `vpc-0619b17e`
 * Subnet ID: `subnet-124f5848`
@@ -25,6 +25,20 @@ ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-35-85-224-176.us-west-2.com
 
 ```bash
 ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-34-209-209-37.us-west-2.compute.amazonaws.com
+```
+
+### Instance `P4Research3`
+
+Note: `P4Research2` and `P4Research2` share the same EFS volume.
+
+* Instance ID: `i-0eb0cdd4eb6d6a6e3`
+* File system ID: `fs-0186b686e7dffc35b`
+* VPC: `vpc-0619b17e`
+* Subnet ID: `subnet-124f5848`
+* AZ: `us-west-2c`
+
+```bash
+ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-16-147-216-186.us-west-2.compute.amazonaws.com
 ```
 
 

--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -406,9 +406,8 @@ class TrainArgs:
     """
     Modified training-related arguments in :class:`litgpt.args.TrainArgs`.
 
-    Here, `global_batch_size` does not have a default value. If not given,
-    it should be set to the product of `micro_batch_size` and the number of
-    devices, unless sequential gradient averaging is desired.
+    `global_batch_size` is a legacy argument, which must be equal to the
+    product of `micro_batch_size` and the number of devices, if given.
 
     Storing intermediate checkpoints: Normal checkpoints are stored whenever
     `state["step_count"] % train.save_interval == 0`. If
@@ -437,7 +436,7 @@ class TrainArgs:
     log_interval: int = 1
     """Number of iterations between logging calls"""
     global_batch_size: Optional[int] = None
-    """Number of samples between optimizer steps across data-parallel ranks"""
+    """Legacy argument: Do not use"""
     micro_batch_size: int = 4
     """Number of samples per data-parallel rank"""
     lr_warmup_steps: Optional[int] = 100
@@ -506,23 +505,6 @@ class TrainArgs:
         if self.max_grad_norm is not None and self.max_grad_norm <= 0:
             raise ValueError("max_grad_norm must be positive (or `None` to disable)")
 
-    def gradient_accumulation_iters(self, devices: int, num_nodes: int = 1) -> int:
-        """Number of iterations between gradient synchronizations"""
-        gradient_accumulation_iters = (
-            self.batch_size(devices, num_nodes) // self.micro_batch_size
-        )
-        assert gradient_accumulation_iters > 0
-        return gradient_accumulation_iters
-
-    def batch_size(self, devices: int, num_nodes: int = 1) -> int:
-        """Number of samples between optimizer steps per data-parallel rank"""
-        if self.global_batch_size is None:
-            batch_size = self.micro_batch_size
-        else:
-            batch_size = self.global_batch_size // (devices * num_nodes)
-        assert batch_size > 0
-        return batch_size
-
     def warmup_iters(
         self, devices: int, num_nodes: int, max_iters: int, train_dataloader
     ) -> int:
@@ -532,11 +514,7 @@ class TrainArgs:
                 max_iters, math.ceil(self.lr_warmup_fraction * len(train_dataloader))
             )
         if self.lr_warmup_steps:
-            return min(
-                max_iters,
-                self.lr_warmup_steps
-                * self.gradient_accumulation_iters(devices, num_nodes),
-            )
+            return min(max_iters, self.lr_warmup_steps)
         return 0
 
 

--- a/keys_values/finetune/longcon_offload_full.py
+++ b/keys_values/finetune/longcon_offload_full.py
@@ -216,7 +216,6 @@ def setup(
         out_dir,
         precision,
         devices,
-        1,
         resume,
         data,
         train,

--- a/keys_values/finetune/longcon_offload_lora.py
+++ b/keys_values/finetune/longcon_offload_lora.py
@@ -231,7 +231,6 @@ def setup(
         out_dir,
         precision,
         devices,
-        1,
         resume,
         data,
         train,

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -85,7 +85,6 @@ from keys_values.finetune.utils import (
     check_kv_cache,
     create_optimizer,
     may_match_twice_factory,
-    fix_dtype_of_score_buffers,
     adjust_cache_kwargs,
 )
 from keys_values.generate.base import generate
@@ -141,7 +140,6 @@ def setup(
     out_dir: Path = Path(DEFAULT_OUT_DIR),
     precision: Optional[str] = None,
     devices: Union[int, str] = 1,
-    num_nodes: int = 1,
     resume: Union[bool, Literal["auto"], Path] = False,
     data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
@@ -226,7 +224,6 @@ def setup(
             /teamspace/jobs/<job-name>/share.
         precision: The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true".
         devices: How many devices/GPUs to use
-        num_nodes: How many nodes the code is being run on.
         resume: Path to a checkpoint directory to resume from in case training
             was interrupted, or ``True`` to resume from the latest checkpoint in
             ``out_dir``. An error will be raised if no checkpoint is found. Passing
@@ -319,7 +316,6 @@ def setup(
         out_dir,
         precision,
         devices,
-        num_nodes,
         resume,
         data,
         train,
@@ -357,7 +353,6 @@ def setup_internal(
     out_dir: Path,
     precision: Optional[str],
     devices: Union[int, str],
-    num_nodes: int,
     resume: Union[bool, Literal["auto"], Path],
     data: Optional[DataModule],
     train: TrainArgs,
@@ -386,7 +381,7 @@ def setup_internal(
     size_log_quantiles: Optional[str],
     debug_dont_use_autograd_hooks: bool,
 ) -> None:
-    if do_cpu_offload and not torch.cuda.is_available():
+    if not torch.cuda.is_available():
         raise ValueError("CUDA not available")
     checkpoint_dir = auto_download_checkpoint(
         model_name=checkpoint_dir,
@@ -410,14 +405,10 @@ def setup_internal(
     if head_model_kwargs is None:
         head_model_kwargs = dict()
     devices = parse_devices(devices)
-    if do_cpu_offload and not (1 <= devices <= torch.cuda.device_count()):
+    if not (1 <= devices <= torch.cuda.device_count()):
         raise ValueError(
             f"devices = {devices}, must be in [1, {torch.cuda.device_count()}]"
         )
-    if num_nodes <= 0:
-        raise ValueError(f"num_nodes = {num_nodes}, must be positive")
-    if do_cpu_offload and num_nodes > 1:
-        raise ValueError(f"Must have num_nodes = 1 with CPU offloading")
     if eval.initial_validation is None:
         # Run initial evaluation in multi-device setup, but not with a
         # single device
@@ -431,22 +422,10 @@ def setup_internal(
         print(str(optimizer))
     if train.max_grad_norm is not None:
         print(f"Using gradient clipping with max_grad_norm = {train.max_grad_norm}")
-    global_batch_size = train.micro_batch_size * devices * num_nodes
-    if train.global_batch_size is None:
+    global_batch_size = train.micro_batch_size * devices
+    if train.global_batch_size != global_batch_size:
+        print(f"train.global_batch_size not supported, set to {global_batch_size}")
         train.global_batch_size = global_batch_size
-    elif do_cpu_offload:
-        if train.global_batch_size != global_batch_size:
-            print(f"train.global_batch_size not supported, set to {global_batch_size}")
-            train.global_batch_size = global_batch_size
-    elif (
-        train.global_batch_size % global_batch_size != 0
-        or train.global_batch_size < global_batch_size
-    ):
-        raise ValueError(
-            f"train.global_batch_size = {train.global_batch_size}, must be "
-            "positive multiple of devices * num_nodes * train.micro_batch_size = "
-            f"{global_batch_size}."
-        )
     if profile_parts is not None and profile_parts not in ("forward", "backward"):
         raise ValueError("profile_parts: Must be 'forward' or 'backward'")
     if size_log_quantiles is not None:
@@ -465,11 +444,6 @@ def setup_internal(
         print(
             "Warning: Device out of memory error recovery does not properly "
             "work at the moment."
-        )
-    gradacc_iters = train.gradient_accumulation_iters(devices, num_nodes)
-    if gradacc_iters > 1:
-        print(
-            f"Using sequential gradient accumulation with {gradacc_iters} iterations per update step"
         )
     # Legacy arguments
     if verbose is None:
@@ -521,14 +495,14 @@ def setup_internal(
         log_interval=train.log_interval,
     )
 
-    if devices * num_nodes > 1:
+    if devices > 1:
         strategy = DDPStrategy(static_graph=True, broadcast_buffers=False)
     else:
         strategy = "auto"
 
     fabric = L.Fabric(
         devices=devices,
-        num_nodes=num_nodes,
+        num_nodes=1,
         strategy=strategy,
         precision=precision,
         loggers=logger,
@@ -546,7 +520,6 @@ def setup_internal(
         do_cpu_offload=do_cpu_offload,
         original_setup=original_setup,
         devices=devices,
-        num_nodes=num_nodes,
         resume=resume,
         seed=seed,
         config=config,
@@ -595,7 +568,6 @@ def main(
     do_cpu_offload: bool,
     original_setup: Callable,
     devices: int,
-    num_nodes: int,
     resume: Union[bool, Literal["auto"], Path],
     seed: int,
     config: Union[ConfigFull, ConfigLoRA],
@@ -737,8 +709,6 @@ def main(
     if do_cpu_offload:
         # We use a optimizer on CPU for all parameters of `gpt_model`. If
         # `head_model` has parameters, we use another optimizer on GPU for them.
-        # Note: We do not wrap model or optimizer with `fabric`, since our CPU
-        # offloading deviates from their strategies.
         gpt_param_prefixes = tuple(
             BlockComponentName.h(layer_idx) for layer_idx in range(config.n_layer)
         ) + (
@@ -763,7 +733,6 @@ def main(
             "cpu_optimizer": cpu_optimizer,
             "cpu_scheduler": cpu_scheduler,
             "iter_num": 0,
-            "step_count": 0,
         }
         head_model_params = list(head_model.parameters())
         if head_model_params:
@@ -778,18 +747,14 @@ def main(
                 max_steps=lr_max_steps,
             )
     else:
-        model = fabric.setup(model)
-        # After `fabric.setup`, the score buffers in
-        # :class:`AttnWeightsKVCache` KV cache have their `dtype`
-        # changed to the default dtype. We need to change them back to
-        # `float32`.
-        fix_dtype_of_score_buffers(model.gpt_model)
+        # Note: We do not wrap `model` or `optimizer` in `fabric`, since we do
+        # not use their abstraction (which creates endless trouble with DDP,
+        # such as autograd graphs not being deallocated)
         optimizer = instantiate_torch_optimizer(
             optimizer.name,
             model.parameters(),
             **optimizer.optimizer_kwargs(),
         )
-        optimizer = fabric.setup_optimizers(optimizer)
         scheduler = get_lr_scheduler(
             optimizer, train_args=train, max_steps=lr_max_steps
         )
@@ -799,7 +764,6 @@ def main(
             "optimizer": optimizer,
             "scheduler": scheduler,
             "iter_num": 0,
-            "step_count": 0,
         }
 
     if eval.use_sample_metric:
@@ -846,7 +810,6 @@ def main(
         val_dataloader=val_dataloader,
         batch_transform=batch_transform,
         devices=devices,
-        num_nodes=num_nodes,
         checkpoint_dir=checkpoint_dir,
         out_dir=out_dir,
         train=train,
@@ -1180,7 +1143,6 @@ def fit(
     val_dataloader: MyDataLoader,
     batch_transform: BatchTransform,
     devices: int,
-    num_nodes: int,
     checkpoint_dir: Path,
     out_dir: Path,
     train: TrainArgs,
@@ -1203,12 +1165,17 @@ def fit(
         cpu_optimizer = None
         cpu_scheduler = None
         optim_device = fabric.device
+        grad_reducer = CPUOffloadAccumulateGradients(
+            group=list(range(devices)),
+            fabric=fabric,
+        )
     else:
         gpu_optimizer = state.get("gpu_optimizer")
         gpu_scheduler = state.get("gpu_scheduler")
         cpu_optimizer = state["cpu_optimizer"]
         cpu_scheduler = state["cpu_scheduler"]
         optim_device = torch.device("cpu")
+        grad_reducer = None
     if evaluator is None:
         eval_metric_name = "val_loss"
     else:
@@ -1406,10 +1373,7 @@ def fit(
         else:
             size_logs = None
 
-        running_loss = RunningMean(
-            window=train.gradient_accumulation_iters(devices, num_nodes),
-            sync_on_compute=False,
-        ).to(optim_device)
+        running_loss = RunningMean(window=1, sync_on_compute=False).to(optim_device)
         fabric.barrier()
         total_lengths = 0
         gc.collect()
@@ -1420,7 +1384,7 @@ def fit(
         )
         total_t0 = time.perf_counter()
 
-        while state["step_count"] < max_steps:
+        while state["iter_num"] < max_steps:
             state["iter_num"] += 1
             iter_t0 = time.perf_counter()
             batch = batch_transform(next(train_iterator))
@@ -1477,19 +1441,19 @@ def fit(
             # )
             # model.gpt_model.reset()
             # END DEBUG
-            is_accumulating = (not do_cpu_offloading) and state[
-                "iter_num"
-            ] % train.gradient_accumulation_iters(devices, num_nodes) != 0
             print_with_rank_and_timestamp(
                 "Starting gradient computation.",
                 fabric.global_rank,
             )
 
-            model_kwargs = dict(
+            # Compute loss and gradients
+            # We do not use `fabric.backward`. For CPU offloading, loss and
+            # gradient accumulation happens in `loss.backward` already. Otherwise,
+            # we run an explicit all_reduce.
+            loss = model(
                 input_ids=batch[INPUT_IDS_NAME],
                 targets=batch["targets"],
-                scale_factor=loss_weight
-                / train.gradient_accumulation_iters(devices, num_nodes),
+                scale_factor=loss_weight,
                 record_gpu_memory_snapshots=record_gpu_memory_snapshots,
                 record_gpu_memory_kind=(
                     record_gpu_memory_kind
@@ -1497,16 +1461,17 @@ def fit(
                     else None
                 ),
             )
+            loss.backward()
+
             if not do_cpu_offloading:
-                with fabric.no_backward_sync(model, enabled=is_accumulating):
-                    loss = model(**model_kwargs)
-                    fabric.backward(loss)
-            else:
-                # Note: We do not use `fabric.backward` here. If `devices > 1`,
-                # gradient accumulation happens in `model.backward`, using
-                # `fabric.all_reduce` explicitly.
-                loss = model(**model_kwargs)
-                loss.backward()
+                module_pairs = [(model.gpt_model, None)]
+                if model.head_model.parameters():
+                    module_pairs.append((model.head_model, None))
+                grad_reducer(
+                    module_pairs=module_pairs,
+                    mean_reduction=True,
+                )
+                fabric.all_reduce(loss, reduce_op="mean")
 
             running_loss.update(loss.detach().to(device=optim_device))
             flush_io_streams()
@@ -1552,23 +1517,21 @@ def fit(
                 record_gpu_memory_snapshots.store_current_snapshot()
                 record_gpu_memory_snapshots.stop_recording()
 
-            if not is_accumulating:
-                if train.max_grad_norm is not None:
-                    torch.nn.utils.clip_grad_norm_(
-                        model.parameters(),
-                        train.max_grad_norm,
-                    )
-                if cpu_optimizer is not None:
-                    cpu_optimizer.step()
-                    cpu_optimizer.zero_grad(set_to_none=True)
-                    cpu_scheduler.step()
-                if gpu_optimizer is not None:
-                    gpu_optimizer.step()
-                    gpu_optimizer.zero_grad(set_to_none=True)
-                    gpu_scheduler.step()
-                print_message("Optimizer update done.", fabric)
-                state["step_count"] += 1
-                check_for_nan_module_weights(model.gpt_model)
+            if train.max_grad_norm is not None:
+                torch.nn.utils.clip_grad_norm_(
+                    model.parameters(),
+                    train.max_grad_norm,
+                )
+            if cpu_optimizer is not None:
+                cpu_optimizer.step()
+                cpu_optimizer.zero_grad(set_to_none=True)
+                cpu_scheduler.step()
+            if gpu_optimizer is not None:
+                gpu_optimizer.step()
+                gpu_optimizer.zero_grad(set_to_none=True)
+                gpu_scheduler.step()
+            print_message("Optimizer update done.", fabric)
+            check_for_nan_module_weights(model.gpt_model)
 
             del loss
             gc.collect()
@@ -1606,7 +1569,6 @@ def fit(
                 metrics = {
                     "loss": loss,
                     "iter": state["iter_num"],
-                    "step": state["step_count"],
                     "epoch": train_iterator.epoch,
                     "iter_time": t1 - iter_t0,
                     "tokens": token_counts["raw_tokens_plus_prompt_template"],
@@ -1618,16 +1580,15 @@ def fit(
                 if not isinstance(val_loss, str):
                     val_loss = f"{val_loss:.3f}"
                 print_message(
-                    f"\nEpoch {metrics['epoch']} | iter {metrics['iter']:3d} step {metrics['step']:3d} |"
+                    f"\nEpoch {metrics['epoch']} | iter {metrics['iter']:3d} |"
                     f" loss train: {metrics['loss']:.3f},"
                     f" {eval_metric_name} valid: {val_loss} |"
-                    f" iter time: {metrics['iter_time']:.3f} s"
-                    f"{' (step)' if not is_accumulating else ''}",
+                    f" iter time: {metrics['iter_time']:.3f} s",
                     fabric,
                 )
                 fabric.log_dict(metrics, step=state["iter_num"])
 
-            if not is_accumulating and state["step_count"] % eval.interval == 0:
+            if state["iter_num"] % eval.interval == 0:
                 print_with_rank_and_timestamp(
                     "Starting validation evaluations.",
                     fabric.global_rank,
@@ -1675,17 +1636,16 @@ def fit(
                     del valid_model
                 fabric.barrier()
 
-            if not is_accumulating:
-                save_checkpoint_regular(
-                    fabric=fabric,
-                    model=model,
-                    out_dir=out_dir,
-                    checkpoint_dir=checkpoint_dir,
-                    step=state["step_count"],
-                    train=train,
-                    data=data,
-                    original_setup=original_setup,
-                )
+            save_checkpoint_regular(
+                fabric=fabric,
+                model=model,
+                out_dir=out_dir,
+                checkpoint_dir=checkpoint_dir,
+                step=state["iter_num"],
+                train=train,
+                data=data,
+                original_setup=original_setup,
+            )
 
     except torch._dynamo.exc.FailOnRecompileLimitHit as ex:
         # This error is thrown by FlexAttention if too many graphs have been

--- a/keys_values/finetune/longcontext_lora.py
+++ b/keys_values/finetune/longcontext_lora.py
@@ -37,7 +37,6 @@ def setup(
     out_dir: Path = Path(DEFAULT_OUT_DIR),
     precision: Optional[str] = None,
     devices: Union[int, str] = 1,
-    num_nodes: int = 1,
     resume: Union[bool, Literal["auto"], Path] = False,
     data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
@@ -132,7 +131,6 @@ def setup(
             /teamspace/jobs/<job-name>/share.
         precision: The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true".
         devices: How many devices/GPUs to use
-        num_nodes: How many nodes the code is being run on.
         resume: Path to a checkpoint directory to resume from in case training
             was interrupted, or ``True`` to resume from the latest checkpoint in
             ``out_dir``. An error will be raised if no checkpoint is found. Passing
@@ -230,7 +228,6 @@ def setup(
         out_dir,
         precision,
         devices,
-        num_nodes,
         resume,
         data,
         train,

--- a/keys_values/finetune/utils.py
+++ b/keys_values/finetune/utils.py
@@ -20,7 +20,6 @@ import lightning as L
 from tokenizers import Tokenizer as HFTokenizer
 import torch
 
-from keys_values.data import LongBenchV2
 from keys_values.kvcache.smart_lastrec import SmartInitialInformation
 from litgpt.data import DataModule
 from litgpt.tokenizer import Tokenizer
@@ -461,6 +460,9 @@ def adjust_cache_kwargs(
             cache_kwargs = dict()
         if isinstance(tokenizer, Tokenizer):
             tokenizer = tokenizer.processor
+        assert isinstance(
+            tokenizer, HFTokenizer
+        ), f"type(tokenizer) = {type(tokenizer)} not supported"
         cache_kwargs["tokenizer"] = tokenizer
         smart_lastrec_info = None
         for name in (

--- a/keys_values/kvcache/smart_lastrec.py
+++ b/keys_values/kvcache/smart_lastrec.py
@@ -34,7 +34,7 @@ from keys_values.kvcache.buffers import (
     positions_wrap_around,
 )
 from keys_values.config import Config
-from keys_values.utils import bits_for_torch_dtype, bitsize_of
+from keys_values.utils import bits_for_torch_dtype, bitsize_of, encode
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,6 @@ class SmartInitialInformation:
         max_initial_fraction: Fraction of cache length initial parts can
             occupy at most
         include_end_string: Include end of init sequence in initial part?
-
     """
 
     end_initial_regex: Union[str, re.Pattern]
@@ -74,7 +73,8 @@ def end_initial_regex_from_string(
     do_escape: bool = True,
 ) -> str:
     result = tokenizer.decode(
-        tokenizer.encode(s).ids, skip_special_tokens=True,
+        encode(tokenizer, s),
+        skip_special_tokens=True,
     )
     if do_escape:
         result = re.escape(result)
@@ -406,7 +406,7 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
             match = re.search(self.end_initial_regex, decoded)
             if match is not None:
                 raw_length = match.end(0) if self.include_end_string else match.start(0)
-                init_encoded = self.tokenizer.encode(decoded[:raw_length]).ids
+                init_encoded = encode(self.tokenizer, decoded[:raw_length])
                 new_length = len(init_encoded)
                 try:
                     diff_pos = next(

--- a/keys_values/kvcache/test_utils_advanced.py
+++ b/keys_values/kvcache/test_utils_advanced.py
@@ -136,14 +136,9 @@ def load_tokenizer(
     return tokenizer
 
 
-class MockEncoding:
-    def __init__(self, ids: List[int]):
-        self.ids = ids
-
-
 class MockTokenizer:
-    def encode(self, dec: str) -> MockEncoding:
-        return MockEncoding([int(x) for x in dec.encode("utf-8")])
+    def encode(self, dec: str) -> List[int]:
+        return [int(x) for x in dec.encode("utf-8")]
 
     def decode(self, enc: List[int], **kwargs) -> str:
         return bytes(enc).decode("utf-8")

--- a/keys_values/optimize/grad_accumulate.py
+++ b/keys_values/optimize/grad_accumulate.py
@@ -65,6 +65,22 @@ class DistributedPrimitives:
             else:
                 dist.all_reduce(x, op=dist.ReduceOp.SUM, group=group)
 
+    @staticmethod
+    def all_reduce_mean(
+        x: torch.Tensor,
+        fabric: Optional[L.Fabric] = None,
+        group: Optional[List[int]] = None,
+    ):
+        if fabric is not None or torch.cuda.is_available():
+            if x.device != DistributedPrimitives.device(fabric):
+                raise ValueError(
+                    f"x.device = {x.device}, must be {DistributedPrimitives.device(fabric)}"
+                )
+            if fabric is not None:
+                fabric.all_reduce(x, reduce_op="mean")
+            else:
+                dist.all_reduce(x, op=dist.ReduceOp.AVG, group=group)
+
 
 DebugStoreGradsNamePredicate = Callable[[str], bool]
 
@@ -77,6 +93,12 @@ class CPUOffloadAccumulateGradients:
     the reductions are done for flat vectors. If the group size is 1, `dist`
     is not used at all, and `group[0]` does not matter.
 
+    This class is used to implement distributed data parallel (DDP) optimization
+    with CPU offloading, where the full model and optimizer state resides on the
+    host (CPU), but gradients are accumulated on the device (GPU).
+
+    We also use it to implement standard DDP, with model and optimizer states
+    on devices, see :meth:`__call__`.
     """
 
     def __init__(
@@ -110,23 +132,55 @@ class CPUOffloadAccumulateGradients:
         self._debug_store_grads_name_predicate = debug_store_grads_name_predicate
         self._debug_iter_count = 0
 
+    @staticmethod
+    def _is_mean_reducible(dtype: torch.dtype) -> bool:
+        return (
+            dtype == torch.float16
+            or dtype == torch.bfloat16
+            or dtype == torch.float32
+            or dtype == torch.float64
+        )
+
+    def _all_reduce(self, vec: torch.Tensor, mean_reduction: bool):
+        if mean_reduction and self._is_mean_reducible(vec.dtype):
+            DistributedPrimitives.all_reduce_mean(
+                vec,
+                self.fabric,
+                self.group,
+            )
+        else:
+            DistributedPrimitives.all_reduce_sum(
+                vec,
+                self.fabric,
+                self.group,
+            )
+
     def __call__(
         self,
-        module_pairs: List[Tuple[torch.nn.Module, torch.nn.Module]],
+        module_pairs: List[Tuple[torch.nn.Module, Optional[torch.nn.Module]]],
         module_on_device: Optional[torch.nn.Module] = None,
         debug_modules: Optional[List[torch.nn.Module]] = None,
+        mean_reduction: bool = False,
     ) -> Optional[float]:
         """
         Run gradient accumulation for module pairs `(mod_from, mod_to)`. This
         is called by every rank from `group`, and the ranks are synchronized
         here.
 
+        By default, for the tuples `(mod_from, mod_to)`, `mod_from` is on the
+        device, `mod_to` on the host (CPU). We also support DDP without CPU
+        offloading, in which case `mod_to == None`, and gradients are written
+        back to `mod_from` after accumulation.
+
         Args:
             module_pairs: List of `(mod_from, mod_to)` tuples. Here, `mod_from`
-                is on the device, `mod_to` is on the CPU.
+                is on the device, `mod_to` is on the CPU. If `mod_to == None`,
+                gradients are written back to `mod_from`.
             module_on_device: If given, this source module is on the device.
                 Its gradients are accumulated if the group size is > 1.
             debug_modules: Use for debugging only. Only for group size 1.
+            mean_reduction: If `True`, use mean reduction in `all_reduce`, otherwise
+                sum reduction. Mean reduction is done only for floating point types.
 
         Returns:
             Idle time in seconds at `all_reduce` sync point, or `None` if not
@@ -134,6 +188,12 @@ class CPUOffloadAccumulateGradients:
 
         """
         use_dist = self.is_distributed
+        num_none = sum(mod_to is None for _, mod_to in module_pairs)
+        do_offload = num_none == 0
+        if not do_offload and num_none != len(module_pairs):
+            raise ValueError(
+                "Entries of module_pairs: Either all mod_to are None, or none"
+            )
         if debug_modules is None:
             debug_modules = [None] * len(module_pairs)
         else:
@@ -148,19 +208,18 @@ class CPUOffloadAccumulateGradients:
                 idle_time_now = None
                 start_time = time.perf_counter()
                 for vec in flat_vectors.values():
-                    DistributedPrimitives.all_reduce_sum(
-                        vec,
-                        self.fabric,
-                        self.group,
-                    )
+                    self._all_reduce(vec, mean_reduction)
                     if idle_time_now is None:
                         idle_time_now = time.perf_counter() - start_time
                 if idle_time_now is not None:
                     idle_time += idle_time_now
             mod_from.zero_grad(set_to_none=True)
-            flat_vectors = {
-                k: v.to(device=torch.device("cpu")) for k, v in flat_vectors.items()
-            }
+            if do_offload:
+                flat_vectors = {
+                    k: v.to(device=torch.device("cpu")) for k, v in flat_vectors.items()
+                }
+            else:
+                mod_to = mod_from
             AccessWeightsGradients(mod_to).accumulate_gradients(flat_vectors)
 
             if mod_debug is not None:
@@ -180,11 +239,7 @@ class CPUOffloadAccumulateGradients:
             flat_vectors = access.get_gradients()
             if use_dist:
                 for vec in flat_vectors.values():
-                    DistributedPrimitives.all_reduce_sum(
-                        vec,
-                        self.fabric,
-                        self.group,
-                    )
+                    self._all_reduce(vec, mean_reduction)
             AccessWeightsGradients(module_on_device).accumulate_gradients(flat_vectors)
 
         return idle_time if use_dist else None

--- a/keys_values/utils.py
+++ b/keys_values/utils.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import csv
-import sys
 from enum import unique, Enum
-
 from filelock import FileLock, Timeout
 from pathlib import Path
+import sys
 import time
 from typing import List, Dict, Any, Optional, Iterable, Union, Iterator, Tuple, Set
 
+from tokenizers import Tokenizer as HFTokenizer
 import torch
 from tqdm import tqdm
+
+from litgpt.tokenizer import Tokenizer
 
 # Currently, `F.scaled_dot_product_attention` does not properly support the
 # case `enabla_gqa=True` (i.e., keys and values have less heads than
@@ -355,3 +357,16 @@ def remove_keys(
     names: Set[str],
 ) -> Dict[str, Any]:
     return {k: v for k, v in kwargs.items() if k not in names}
+
+
+def encode(
+    tokenizer: Union[Tokenizer, HFTokenizer],
+    s: str,
+    **kwargs,
+) -> List[int]:
+    if isinstance(tokenizer, Tokenizer):
+        tokenizer = tokenizer.processor
+    result = tokenizer.encode(s, **kwargs)
+    if hasattr(result, "ids"):
+        result = result.ids
+    return result

--- a/test/kvcache/test_smart_lastrec.py
+++ b/test/kvcache/test_smart_lastrec.py
@@ -34,7 +34,7 @@ from keys_values.kvcache.test_utils_advanced import (
     load_tokenizer,
     sequence_of_words,
 )
-from keys_values.utils import randint_torch
+from keys_values.utils import randint_torch, encode
 
 
 def sample_slot_values(
@@ -166,7 +166,7 @@ def test_smart_lastrec_set_init_length(
         # Tokenize and pad sequences. We do left padding, the number of
         # pad tokens need to be added to `expected_init_length`
         encoded_seqs = [
-            tokenizer.encode(seq, return_tensors="pt").squeeze(0) for seq in sequences
+            encode(tokenizer, seq, return_tensors="pt").squeeze(0) for seq in sequences
         ]
         kwargs = dict(dtype=encoded_seqs[0].dtype)
         max_length = max([x.numel() for x in encoded_seqs])


### PR DESCRIPTION
Don't use DDP provided by Lightning Fabric. Instead, just do the `all_reduce` at the end of each iteration.
This is a major simplification, and results seem to get better.

Closes #88, #92, #98.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
