### PR TITLE
Refactoring and cleaning up fused operators. Change of create_random_…

### DIFF
--- a/docs/launch_instance.md
+++ b/docs/launch_instance.md
@@ -12,7 +12,7 @@
 * AZ: `us-west-2b`
 
 ```bash
-ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-35-85-224-176.us-west-2.compute.amazonaws.com
+ssh -i "~/matthis_deeplearning_uswest2.pem" ubuntu@ec2-35-85-224-176.us-west-2.compute.amazonaws.com
 ```
 
 ### Instance `P4Research2`
@@ -24,7 +24,7 @@ ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-35-85-224-176.us-west-2.com
 * AZ: `us-west-2c`
 
 ```bash
-ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-34-209-209-37.us-west-2.compute.amazonaws.com
+ssh -i "~/matthis_deeplearning_uswest2.pem" ubuntu@ec2-34-209-209-37.us-west-2.compute.amazonaws.com
 ```
 
 ### Instance `P4Research3`
@@ -38,7 +38,7 @@ Note: `P4Research2` and `P4Research2` share the same EFS volume.
 * AZ: `us-west-2c`
 
 ```bash
-ssh -i "matthis_deeplearning_uswest2.pem" ubuntu@ec2-16-147-216-186.us-west-2.compute.amazonaws.com
+ssh -i "~/matthis_deeplearning_uswest2.pem" ubuntu@ec2-16-147-216-186.us-west-2.compute.amazonaws.com
 ```
 
 

--- a/keys_values/finetune/longcontext_eval_ext.py
+++ b/keys_values/finetune/longcontext_eval_ext.py
@@ -67,9 +67,14 @@ from keys_values.finetune.utils import (
     print_with_rank_and_timestamp,
     adjust_cache_kwargs,
 )
+from keys_values.fused import (
+    set_fused_swiglu_enabled,
+    set_fused_rmsnorm_enabled,
+)
 from keys_values.head_model_factory import HeadModelFactory
 from keys_values.long_context import LongContextInferenceModel
 from keys_values.lora import Config as ConfigLoRA
+from keys_values.pos_encoding import set_fused_rope_enabled
 from keys_values.utils import (
     flush_io_streams,
     VerbosityLevels,
@@ -371,6 +376,11 @@ def main(
                 raise ValueError(f"Data class path {_data_class_path} is not supported")
             data_class_path = _data_class_path
             data_init_args = _data_init_args
+
+        # Enable/disable fused operators
+        set_fused_rope_enabled(sdpa.fused_rope)
+        set_fused_rmsnorm_enabled(sdpa.fused_rmsnorm)
+        set_fused_swiglu_enabled(sdpa.fused_swiglu)
 
         # Create model
         is_lora = model_type == "lora"

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -94,6 +94,10 @@ from keys_values.finetune.utils import (
     adjust_cache_kwargs,
     copy_config_files,
 )
+from keys_values.fused import (
+    set_fused_swiglu_enabled,
+    set_fused_rmsnorm_enabled,
+)
 from keys_values.generate.base import generate
 from keys_values.gpu_memory import RecordGPUMemory
 from keys_values.head_model import HeadModel, CrossEntropyOnLogits
@@ -122,7 +126,10 @@ from keys_values.model import GPT as GPTFull
 from keys_values.optimize.grad_accumulate import CPUOffloadAccumulateGradients
 from keys_values.optimize.model_factory import BlockComponentName
 from keys_values.parser_config import save_hyperparameters
-from keys_values.pos_encoding import position_encoding_factory
+from keys_values.pos_encoding import (
+    position_encoding_factory,
+    set_fused_rope_enabled,
+)
 from keys_values.tools.size_log import (
     SizeWeightsGradientsLog,
     SizeLogMapper,
@@ -689,6 +696,10 @@ def main(
     else:
         cpu_offload_device = None
         optim_device = fabric.device
+    # Enable/disable fused operators
+    set_fused_rope_enabled(sdpa.fused_rope)
+    set_fused_rmsnorm_enabled(sdpa.fused_rmsnorm)
+    set_fused_swiglu_enabled(sdpa.fused_swiglu)
 
     if fabric.global_rank == 0:
         os.makedirs(out_dir, exist_ok=True)
@@ -985,15 +996,6 @@ def get_mha_and_cache_kwargs(
         init_val=limit_gb,
         name="attention_forward_temp_size_gb",
     )
-    from keys_values.pos_encoding import set_fused_rope_enabled
-
-    set_fused_rope_enabled(sdpa.fused_rope)
-    from keys_values.fused_rmsnorm import set_fused_rmsnorm_enabled
-
-    set_fused_rmsnorm_enabled(sdpa.fused_rmsnorm)
-    from keys_values.fused_swiglu import set_fused_swiglu_enabled
-
-    set_fused_swiglu_enabled(sdpa.fused_swiglu)
     mha_kwargs: Dict[str, Any] = dict(
         tmp_array_limit_gb=tmp_array_limit_forward,
         pos_encoding=position_encoding_factory(config, do_yarn=yarn_rope),

--- a/keys_values/fused/__init__.py
+++ b/keys_values/fused/__init__.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keys_values.fused.fused_rmsnorm import (
+    can_use_fused_rmsnorm,
+    fused_rmsnorm,
+    set_fused_rmsnorm_enabled,
+)
+from keys_values.fused.fused_rope import (
+    can_use_fused_rope,
+    fused_apply_rope,
+)
+from keys_values.fused.fused_swiglu import (
+    can_use_fused_swiglu,
+    fused_swiglu,
+    set_fused_swiglu_enabled,
+)
+
+__all__ = [
+    "can_use_fused_rmsnorm",
+    "can_use_fused_rope",
+    "can_use_fused_swiglu",
+    "fused_apply_rope",
+    "fused_rmsnorm",
+    "fused_swiglu",
+    "set_fused_rmsnorm_enabled",
+    "set_fused_swiglu_enabled",
+]

--- a/keys_values/fused/fused_rmsnorm.py
+++ b/keys_values/fused/fused_rmsnorm.py
@@ -11,24 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fused Triton kernel for RMSNorm.
-
-Replaces the eager RMSNorm forward (x.float() + x*x + mean + rsqrt + x*rsqrt
-+ mul weight + cast = ~5-6 kernels) with a single Triton kernel. Similarly
-for backward. Implemented as torch.autograd.Function so the training cell
-loop's saved_tensors_hooks see a normal autograd function.
-
-Forward:
-  y = (x / sqrt(mean(x**2) + eps)) * weight        (add_unit_offset=False)
-  y = (x / sqrt(mean(x**2) + eps)) * (1 + weight)  (add_unit_offset=True)
-
-Backward (per row, with w' = weight or 1+weight):
-  r = rsqrt(mean_sq + eps)
-  dL/dw = sum_over_batch( dL/dy * x * r )   (in fp32, reduced across all rows)
-  dL/dx = r * w' * dL/dy - (r**3 / D) * (sum_j(dL/dy_j * w'_j * x_j)) * x
-where D is the norm dim size (last dim).
-"""
-
 import torch
 
 _triton_available = False
@@ -227,33 +209,6 @@ if _triton_available:
         tl.store(GradW_ptr + d_offsets, acc, mask=d_mask)
 
 
-def can_use_fused_rmsnorm(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    dim: int,
-) -> bool:
-    """Check if `fused_rmsnorm` can handle this input."""
-    if not _triton_available:
-        return False
-    if not x.is_cuda:
-        return False
-    if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-        return False
-    if x.dim() < 2:
-        return False
-    # Only support reducing along the last dim (the common case)
-    if dim != -1 and dim != x.dim() - 1:
-        return False
-    D = x.shape[-1]
-    if weight.numel() != D:
-        return False
-    # Triton block size must fit the hidden dim; cap at 16384 to stay within
-    # shared memory budgets
-    if D > 16384:
-        return False
-    return True
-
-
 def _next_power_of_two(n: int) -> int:
     p = 1
     while p < n:
@@ -261,7 +216,26 @@ def _next_power_of_two(n: int) -> int:
     return p
 
 
-class _FusedRMSNorm(torch.autograd.Function):
+class FusedRMSNorm(torch.autograd.Function):
+    """Fused Triton kernel for RMSNorm.
+
+    Replaces the eager RMSNorm forward (x.float() + x*x + mean + rsqrt + x*rsqrt
+    + mul weight + cast = ~5-6 kernels) with a single Triton kernel.
+    Implemented as torch.autograd.Function so the training cell
+    loop's saved_tensors_hooks see a normal autograd function.
+
+    Forward:
+      y = (x / sqrt(mean(x**2) + eps)) * weight        (add_unit_offset=False)
+      y = (x / sqrt(mean(x**2) + eps)) * (1 + weight)  (add_unit_offset=True)
+
+    Backward (per row, with w' = weight or 1+weight):
+      r = rsqrt(mean_sq + eps)
+      dL/dw = sum_over_batch( dL/dy * x * r )   (in fp32, reduced across all rows)
+      dL/dx = r * w' * dL/dy - (r**3 / D) * (sum_j(dL/dy_j * w'_j * x_j)) * x
+    where D is the norm dim size (last dim).
+
+    """
+
     @staticmethod
     def forward(ctx, x, weight, eps, add_unit_offset):
         if not can_use_fused_rmsnorm(x, weight, -1):
@@ -397,6 +371,33 @@ class _FusedRMSNorm(torch.autograd.Function):
         return grad_x.view(ctx.original_shape), grad_w, None, None
 
 
+def can_use_fused_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    dim: int,
+) -> bool:
+    """Check if `fused_rmsnorm` can handle this input."""
+    if not _triton_available:
+        return False
+    if not x.is_cuda:
+        return False
+    if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return False
+    if x.dim() < 2:
+        return False
+    # Only support reducing along the last dim (the common case)
+    if dim != -1 and dim != x.dim() - 1:
+        return False
+    D = x.shape[-1]
+    if weight.numel() != D:
+        return False
+    # Triton block size must fit the hidden dim; cap at 16384 to stay within
+    # shared memory budgets
+    if D > 16384:
+        return False
+    return True
+
+
 def fused_rmsnorm(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -414,7 +415,7 @@ def fused_rmsnorm(
     Returns:
         Normalized tensor, same shape and dtype as x.
     """
-    return _FusedRMSNorm.apply(x, weight, eps, add_unit_offset)
+    return FusedRMSNorm.apply(x, weight, eps, add_unit_offset)
 
 
 # Module-level flag controlling whether RMSNorm classes are patched to use the

--- a/keys_values/fused/fused_rope.py
+++ b/keys_values/fused/fused_rope.py
@@ -11,23 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fused Triton kernel for rotary position embedding (RoPE).
-
-Replaces the eager apply_rope() sequence (slice + negate + cat + mul + mul +
-add + to-dtype = ~5-6 kernels) with a single Triton kernel. Forward and
-backward are both implemented as torch.autograd.Function, so the training
-cell loop's saved_tensors_hooks see normal autograd functions and continue
-to work unchanged.
-
-Forward:
-  y = x * cos + rot(x) * sin
-where rot(x) = cat(-x[..., half:], x[..., :half], dim=-1).
-
-Backward (see pos_encoding.py derivation):
-  dL/dx_j for j < half = dL/dy_j * cos_j + dL/dy_{j+half} * sin_{j+half}
-  dL/dx_j for j >= half = dL/dy_j * cos_j - dL/dy_{j-half} * sin_{j-half}
-"""
-
 from typing import Tuple
 
 import torch
@@ -186,33 +169,6 @@ if _triton_available:
         tl.store(GradX_ptr + gx_offsets, gx, mask=t_mask[:, None])
 
 
-def can_use_fused_rope(
-    x: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-) -> bool:
-    """Check if `fused_apply_rope` can handle this input."""
-    if not _triton_available:
-        return False
-    if not x.is_cuda:
-        return False
-    if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-        return False
-    if x.dim() < 2:
-        return False
-    D = x.shape[-1]
-    if D % 2 != 0:
-        return False
-    if cos.shape != sin.shape:
-        return False
-    if cos.shape[-1] != D:
-        return False
-    T = x.shape[-2]
-    if cos.numel() != T * D:
-        return False
-    return True
-
-
 def _reshape_inputs(
     x: torch.Tensor,
     cos: torch.Tensor,
@@ -230,7 +186,25 @@ def _reshape_inputs(
     return x_view, cos_view, sin_view, BH, T, D, original_shape
 
 
-class _FusedRope(torch.autograd.Function):
+class FusedRoPE(torch.autograd.Function):
+    """Fused Triton kernel for rotary position embedding (RoPE).
+
+    Replaces the eager apply_rope() sequence (slice + negate + cat + mul + mul +
+    add + to-dtype = ~5-6 kernels) with a single Triton kernel. Forward and
+    backward are both implemented as torch.autograd.Function, so the training
+    cell loop's saved_tensors_hooks see normal autograd functions and continue
+    to work unchanged.
+
+    Forward:
+      y = x * cos + rot(x) * sin
+    where rot(x) = cat(-x[..., half:], x[..., :half], dim=-1).
+
+    Backward (see pos_encoding.py derivation):
+      dL/dx_j for j < half = dL/dy_j * cos_j + dL/dy_{j+half} * sin_{j+half}
+      dL/dx_j for j >= half = dL/dy_j * cos_j - dL/dy_{j-half} * sin_{j-half}
+
+    """
+
     @staticmethod
     def forward(ctx, x, cos, sin):
         if not can_use_fused_rope(x, cos, sin):
@@ -309,6 +283,33 @@ class _FusedRope(torch.autograd.Function):
         return grad_x.view(ctx.original_shape), None, None
 
 
+def can_use_fused_rope(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> bool:
+    """Check if `fused_apply_rope` can handle this input."""
+    if not _triton_available:
+        return False
+    if not x.is_cuda:
+        return False
+    if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return False
+    if x.dim() < 2:
+        return False
+    D = x.shape[-1]
+    if D % 2 != 0:
+        return False
+    if cos.shape != sin.shape:
+        return False
+    if cos.shape[-1] != D:
+        return False
+    T = x.shape[-2]
+    if cos.numel() != T * D:
+        return False
+    return True
+
+
 def fused_apply_rope(
     x: torch.Tensor,
     cos: torch.Tensor,
@@ -324,4 +325,4 @@ def fused_apply_rope(
     Returns:
         RoPE-transformed tensor, same shape and dtype as x.
     """
-    return _FusedRope.apply(x, cos, sin)
+    return FusedRoPE.apply(x, cos, sin)

--- a/keys_values/fused/fused_swiglu.py
+++ b/keys_values/fused/fused_swiglu.py
@@ -11,24 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fused Triton kernel for SwiGLU (silu(a) * b).
-
-Replaces the eager LLaMAMLP inner sequence `F.silu(x_fc_1) * x_fc_2`
-(2 kernels: silu + elementwise multiply) with a single Triton kernel.
-Forward and backward are both implemented as torch.autograd.Function so
-the training cell loop's saved_tensors_hooks see a normal autograd
-function.
-
-Math:
-  silu(a) = a * sigmoid(a)
-  y = silu(a) * b
-
-Backward (with s = sigmoid(a), f = silu(a) = a * s):
-  dL/da = dL/dy * b * s * (1 + a * (1 - s))
-        = dL/dy * b * (s + f * (1 - s))
-  dL/db = dL/dy * f
-"""
-
 import torch
 
 _triton_available = False
@@ -91,22 +73,26 @@ if _triton_available:
         tl.store(GradB_ptr + offsets, gb.to(B_ptr.dtype.element_ty), mask=mask)
 
 
-def can_use_fused_swiglu(a: torch.Tensor, b: torch.Tensor) -> bool:
-    """Check if `fused_swiglu` can handle these inputs."""
-    if not _triton_available:
-        return False
-    if not a.is_cuda:
-        return False
-    if a.shape != b.shape:
-        return False
-    if a.dtype != b.dtype:
-        return False
-    if a.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-        return False
-    return True
+class FusedSwiGLU(torch.autograd.Function):
+    """Fused Triton kernel for SwiGLU (silu(a) * b).
 
+    Replaces the eager LLaMAMLP inner sequence `F.silu(x_fc_1) * x_fc_2`
+    (2 kernels: silu + elementwise multiply) with a single Triton kernel.
+    Forward and backward are both implemented as torch.autograd.Function so
+    the training cell loop's saved_tensors_hooks see a normal autograd
+    function.
 
-class _FusedSwiGLU(torch.autograd.Function):
+    Math:
+      silu(a) = a * sigmoid(a)
+      y = silu(a) * b
+
+    Backward (with s = sigmoid(a), f = silu(a) = a * s):
+      dL/da = dL/dy * b * s * (1 + a * (1 - s))
+            = dL/dy * b * (s + f * (1 - s))
+      dL/db = dL/dy * f
+
+    """
+
     @staticmethod
     def forward(ctx, a, b):
         if not can_use_fused_swiglu(a, b):
@@ -154,6 +140,21 @@ class _FusedSwiGLU(torch.autograd.Function):
         return grad_a, grad_b
 
 
+def can_use_fused_swiglu(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Check if `fused_swiglu` can handle these inputs."""
+    if not _triton_available:
+        return False
+    if not a.is_cuda:
+        return False
+    if a.shape != b.shape:
+        return False
+    if a.dtype != b.dtype:
+        return False
+    if a.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return False
+    return True
+
+
 def fused_swiglu(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     """Fused SwiGLU: drop-in replacement for `F.silu(a) * b`.
 
@@ -164,13 +165,14 @@ def fused_swiglu(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     Returns:
         Tensor `silu(a) * b`, same shape and dtype as inputs.
     """
-    return _FusedSwiGLU.apply(a, b)
+    return FusedSwiGLU.apply(a, b)
 
 
 # Module-level flag + monkey-patch machinery, following the same pattern as
 # fused_rmsnorm. When enabled, patches LLaMAMLP.forward to use the fused
 # kernel for the silu-mul step.
 _USE_FUSED_SWIGLU = False
+
 _ORIGINAL_FORWARDS = {}
 
 
@@ -190,9 +192,9 @@ def set_fused_swiglu_enabled(enabled: bool):
 
 def _install_or_restore_hooks(install: bool):
     from keys_values.lora import LLaMAMLP as LLaMAMLPLoRA
-    from litgpt.model import LLaMAMLP as LLaMAMLPLitgpt
+    from litgpt.model import LLaMAMLP as LLaMAMLPFull
 
-    classes = [LLaMAMLPLoRA, LLaMAMLPLitgpt]
+    classes = [LLaMAMLPLoRA, LLaMAMLPFull]
 
     if install:
         for cls in classes:

--- a/keys_values/kvcache/gradient/accumulate.py
+++ b/keys_values/kvcache/gradient/accumulate.py
@@ -504,19 +504,15 @@ class GradientAccumulator:
             if self._verbose_more:
                 print("Forward pass to store KV cache checkpoints")
             infer_replay_caches = self._create_inference_replay_caches(model_part)
-            torch.cuda.nvtx.range_push("compute_checkpoints")
             self._compute_checkpoints(
                 model_part,
                 infer_replay_caches,
                 get_inputs_slice,
             )
-            torch.cuda.nvtx.range_pop()
             if torch.cuda.is_available():
                 # Synchronize here to make sure the checkpoints are properly
                 # written to CPU (host), before they are read below
-                torch.cuda.nvtx.range_push("sync_checkpoints")
                 torch.cuda.synchronize()
-                torch.cuda.nvtx.range_pop()
             # We could delete `infer_replay_caches` here. But we still use their
             # buffers to de-quantize checkpoints below
         else:
@@ -562,7 +558,6 @@ class GradientAccumulator:
                 # - Inputs left:     k_buffers, v_buffers
                 # - Gradients top:   head_gradients_top
                 # - Gradients right: head_gradients_k, head_gradients_v
-                torch.cuda.nvtx.range_push(f"cell_inputs_{col_idx}")
                 cell_inputs = copy_requires_grad(get_inputs_slice(start, end))
                 head_gradients_top = get_head_gradients_slice(start, end)
                 if col_idx == 0:
@@ -578,12 +573,10 @@ class GradientAccumulator:
                     )
                     k_buffers = [copy_requires_grad(x) for x in k_buffers]
                     v_buffers = [copy_requires_grad(x) for x in v_buffers]
-                torch.cuda.nvtx.range_pop()
 
                 # Forward-backward, using the autograd hooks (if given)
                 scalar_output = None
                 try:
-                    torch.cuda.nvtx.range_push(f"forward_{col_idx}")
                     with (
                         torch.autograd.graph.saved_tensors_hooks(
                             lambda x: self.autograd_hooks.pack_hook(x),
@@ -603,17 +596,12 @@ class GradientAccumulator:
                             first_chunk_idx=first_chunk_idx,
                             num_chunks=num_chunks,
                         )
-                    torch.cuda.nvtx.range_pop()
 
-                    torch.cuda.nvtx.range_push(f"backward_{col_idx}")
                     scalar_output.backward()
-                    torch.cuda.nvtx.range_pop()
-                    torch.cuda.nvtx.range_push(f"write_head_grads_{col_idx}")
                     write_head_gradients_slice(start, cell_inputs.grad)
                     if col_idx > 0:
                         head_gradients_k = [x.grad for x in k_buffers]
                         head_gradients_v = [x.grad for x in v_buffers]
-                    torch.cuda.nvtx.range_pop()
                 finally:
                     del scalar_output
                     del cell_inputs

--- a/keys_values/kvcache/gradient/annotation.py
+++ b/keys_values/kvcache/gradient/annotation.py
@@ -28,7 +28,7 @@ from keys_values.utils import (
 # `(batch_size, n_query_groups, MAX_DELTA_TRANS_LENGTH, head_size)`. Making
 # this smaller increases the probability of false matches, but speeds up the
 # matching.
-MAX_DELTA_TRANS_LENGTH = 32
+MAX_DELTA_TRANS_LENGTH = 48
 
 _ANNOTATION_KIND_TO_SHORT = {
     "cat-key": "c-k",
@@ -171,30 +171,30 @@ def create_random_index(
     assert len(shape) == 4
     if dtype is None:
         dtype = torch.int64
-    num = min(shape[2], length)
+    num = shape[2]
+    assert num <= length, (shape, length)
+    # Old code:
+    # index_kwargs = dict(dtype=dtype, device=device)
+    # result = torch.empty(shape[:-1], **index_kwargs)
+    # for b in range(shape[0]):
+    #    for h in range(shape[1]):
+    #        result[b, h, :] = torch.randperm(length, **index_kwargs)[:num]
     # Batched random permutation: draw uniform random values of shape
-    # (batch, n_heads, length), argsort along the last dim to produce
-    # independent permutations per (b, h), then slice to `num`.
-    # This replaces a Python `for b, h: torch.randperm(length)` loop — on CUDA
-    # each randperm launches ~7 small kernels, so the loop produced
-    # batch * n_heads * 7 kernel launches; this path produces a handful.
-    if device.type == "cuda":
-        rand_vals = torch.rand(
-            shape[0], shape[1], length, device=device, dtype=torch.float32
+    # (batch, n_heads, length), topk or argsort along the last dim to produce
+    # independent permutations per (b, h).
+    # Replaced a Python nested for loop over b and h, which launched a large
+    # number of CUDA kernels.
+    if num < length:
+        result = (
+            torch.rand(*shape[:2], length, device=device, dtype=torch.float32)
+            .topk(num, dim=-1)
+            .indices
         )
-        # argsort returns int64; cast to the requested dtype below
-        perms = rand_vals.argsort(dim=-1)
-        if num < length:
-            perms = perms[..., :num]
-        result = perms.to(dtype=dtype)
     else:
-        # CPU fallback: keep the original loop — randperm on CPU is a single
-        # call and this path isn't perf-critical anyway.
-        index_kwargs = dict(dtype=dtype, device=device)
-        result = torch.empty(shape[:-1], **index_kwargs)
-        for b in range(shape[0]):
-            for h in range(shape[1]):
-                result[b, h, :] = torch.randperm(length, **index_kwargs)[:num]
+        result = torch.rand(
+            *shape[:2], length, device=device, dtype=torch.float32
+        ).argsort(dim=-1)
+    result = result.to(dtype=dtype)
     return expand_index(result, shape[-1])
 
 
@@ -227,7 +227,8 @@ def create_ext_annotations(
     for buffer, name in ((key, "key"), (value, "value")):
         kind = "ext-" + name
         shape = shape_to_tuple(buffer)
-        index_shape = shape[:2] + (MAX_DELTA_TRANS_LENGTH, shape[-1])
+        ind_shape2 = min(MAX_DELTA_TRANS_LENGTH, shape[2])
+        index_shape = shape[:2] + (ind_shape2, shape[-1])
         index = create_random_index(
             shape=index_shape,
             length=shape[2],

--- a/keys_values/kvcache/gradient/main.py
+++ b/keys_values/kvcache/gradient/main.py
@@ -1203,7 +1203,6 @@ class LongContextGradientModel(LongContextInferenceModel):
                 snapshots = self._record_gpu_memory_snapshots
             else:
                 snapshots = None
-            torch.cuda.nvtx.range_push(f"accumulator_run_{first_layer_idx}")
             self.accumulator.run(
                 model_part=model_part,
                 get_inputs_slice=partial(get_inputs_slice, layer_idx=first_layer_idx),
@@ -1211,7 +1210,6 @@ class LongContextGradientModel(LongContextInferenceModel):
                 write_head_gradients_slice=write_head_gradients_slice,
                 record_gpu_memory_snapshots=snapshots,
             )
-            torch.cuda.nvtx.range_pop()
             if self.offload_device is not None:
                 module_pairs = [
                     (

--- a/keys_values/kvcache/gradient/train_attn_weights_replay.py
+++ b/keys_values/kvcache/gradient/train_attn_weights_replay.py
@@ -498,7 +498,12 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
             print(f"Create {str(annotation)}")
 
     def _random_index(self, num: int) -> torch.Tensor:
-        shape = (self.batch_size, self.n_query_groups, num, self.head_size)
+        shape = (
+            self.batch_size,
+            self.n_query_groups,
+            min(num, self.current_length),
+            self.head_size,
+        )
         return create_random_index(
             shape=shape,
             length=self.current_length,
@@ -658,7 +663,7 @@ class TrainingAttnWeightsReplayCache(DefaultKVCache):
         token_idx: torch.Tensor,
     ) -> Tuple[Optional[torch.Tensor], Optional[UpdateTokenPositionsGracePeriod]]:
         """
-         Processes token chunk, comparing `token_idx` against the current chunk
+        Processes token chunk, comparing `token_idx` against the current chunk
         in the replay log, and advancing `token_chunk_pos`. We also update
         `_token_positions`.
 

--- a/keys_values/kvcache/gradient/train_attn_weights_replay_old.py
+++ b/keys_values/kvcache/gradient/train_attn_weights_replay_old.py
@@ -405,7 +405,12 @@ class TrainingAttnWeightsReplayCacheOld(DefaultKVCache):
             print(f"Create {str(annotation)}")
 
     def _random_index(self, num: int) -> torch.Tensor:
-        shape = (self.batch_size, self.n_query_groups, num, self.head_size)
+        shape = (
+            self.batch_size,
+            self.n_query_groups,
+            min(num, self.current_length),
+            self.head_size,
+        )
         return create_random_index(
             shape=shape,
             length=self.current_length,

--- a/keys_values/long_context.py
+++ b/keys_values/long_context.py
@@ -948,6 +948,9 @@ class LongContextInferenceModel(GPTAndHeadModel):
                     # quantizer buffer) via the default stream's natural
                     # ordering. A `cuda.synchronize()` here would only block
                     # the CPU thread, not add any GPU-level ordering.
+                    # Old code:
+                    # if self._do_checkpoint_layer_input() and torch.cuda.is_available():
+                    #    torch.cuda.synchronize()
                     del embeddings
                     embeddings = torch.cat(new_embed_parts, dim=1)
                     assert embeddings.shape[1] == end - start, (

--- a/keys_values/model.py
+++ b/keys_values/model.py
@@ -762,8 +762,6 @@ class CausalSelfAttention(nn.Module):
                 input_pos=_input_pos,
                 block_idx=self.block_idx,
             )
-            # Skip the outer cat when rope covers the full head dim (e.g.,
-            # Qwen3): the tail slice is empty and cat would just copy.
             if rope_n_elem == head_size:
                 q = q_roped
                 k = k_roped

--- a/keys_values/pos_encoding.py
+++ b/keys_values/pos_encoding.py
@@ -14,10 +14,11 @@
 import math
 from typing import Optional, Dict, Any
 
-from keys_values.config import Config
-from litgpt.model import build_rope_cache, apply_rope
-
 import torch
+
+from litgpt.model import build_rope_cache, apply_rope as apply_rope_litgpt
+
+from keys_values.config import Config
 
 # Opt-in fused Triton RoPE. Toggled via `set_fused_rope_enabled(True)` during
 # model setup (see `SDPAArgs.fused_rope`). Falls back to eager apply_rope if
@@ -30,13 +31,17 @@ def set_fused_rope_enabled(enabled: bool):
     _USE_FUSED_ROPE = enabled
 
 
-def _apply_rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+def apply_rope(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
     if _USE_FUSED_ROPE:
-        from keys_values.fused_rope import fused_apply_rope, can_use_fused_rope
+        from keys_values.fused.fused_rope import fused_apply_rope, can_use_fused_rope
 
         if can_use_fused_rope(x, cos, sin):
             return fused_apply_rope(x, cos, sin)
-    return apply_rope(x=x, cos=cos, sin=sin)
+    return apply_rope_litgpt(x=x, cos=cos, sin=sin)
 
 
 class PositionEncoding:
@@ -230,7 +235,7 @@ class LinearPositionEncoding(PositionEncoding):
                 value=sin,
                 postfix="_rope_sin",
             )
-        return _apply_rope(x=x, cos=cos, sin=sin)
+        return apply_rope(x=x, cos=cos, sin=sin)
 
 
 DEFAULT_YARN_ALPHA = 1.0


### PR DESCRIPTION
…index in annotation.py required increase of MAX_DELTA_TRANS_LENGTH

Fast follow of #105.

The (crucial!) change of `create_random_index` needed some changes:
- Using `topk(...).indices` instead of `argsort` saves time and space
- Increase `MAX_DELTA_TRANS_LENGTH` from 32 to 48, since otherwise tests in `test_gradient.py` fail, due to mismatches

Not sure why this happens, but increasing `MAX_DELTA_TRANS_LENGTH` anyway makes matching more robust.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
