### PR TITLE
Add SM90 CUDA target for H100 support

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -92,6 +92,7 @@ def main():
                     "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
                     "-U__CUDA_NO_HALF2_OPERATORS__",
                     "-gencode=arch=compute_80,code=sm_80",
+                    "-gencode=arch=compute_90,code=sm_90",
                 ],
             },
         )

--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -171,9 +171,7 @@ class KVCacheArgs:
             New :class:`KVCacheArgs` object with `cache_kwargs` updated.
 
         """
-        new_cache_kwargs = {
-            name: getattr(self, name) for name in _CACHE_KWARGS_NAMES
-        }
+        new_cache_kwargs = {name: getattr(self, name) for name in _CACHE_KWARGS_NAMES}
         new_cache_kwargs.update(self.cache_kwargs)
         return replace(self, cache_kwargs=new_cache_kwargs)
 


### PR DESCRIPTION
This PR adds CUDA code generation support for NVIDIA H100 GPUs by including the `sm_90` architecture target in `build_ext.py`.

Previously, `_flashinfer_ops.so` was only compiled with kernels for A100 / `sm_80`. When running on H100 / `sm_90`, CUDA could not find a compatible kernel image at runtime, resulting in an error.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
