### PR TITLE
Evaluation scripts can also write generated samples to files

### DIFF
--- a/keys_values/evaluation/evaluator.py
+++ b/keys_values/evaluation/evaluator.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, List, Union
+from typing import Any, Dict, Optional, List, Union, Tuple
 
 import torch
 
@@ -129,7 +129,8 @@ class SampleBasedMetricsEvaluator:
         model: LongContextInferenceModel,
         prompts: torch.Tensor,
         targets: List[TargetType],
-    ) -> Dict[str, torch.Tensor]:
+        return_samples: bool = False,
+    ) -> Tuple[Dict[str, torch.Tensor], Optional[List[str]]]:
         """
         Computes metric values for data case `(input_ids, targets)`. The
         metrics to be computed are in `metrics`.
@@ -141,11 +142,15 @@ class SampleBasedMetricsEvaluator:
             targets: List of targets of length `batch_size`. Each entry is a
                 string or list of strings. Some metrics allow for lists of
                 strings, others require a single string
+            return_samples: If `True`, we also return a list of generated
+                sequences (of length `batch_size`)
 
         Returns:
             Dictionary with entries `{name: values}`, where `name in self.metrics`
             and `values.shape = (batch_size,)`, the metric values for each
             entry in the batch.
+            If `return_samples == True`, we also return a list of generated
+            sequences.
 
         """
         assert prompts.ndim == 2
@@ -186,4 +191,4 @@ class SampleBasedMetricsEvaluator:
                 device=prompts.device,
             )
             for metric in self.metrics
-        }
+        }, (outputs if return_samples else None)

--- a/keys_values/evaluation/tasks.py
+++ b/keys_values/evaluation/tasks.py
@@ -14,7 +14,7 @@
 from filelock import FileLock, Timeout
 from pathlib import Path
 import re
-from typing import List, Dict, Any, Optional, Iterable, Tuple
+from typing import List, Dict, Any, Optional, Iterable, Tuple, Literal
 
 from keys_values.data.base import (
     LIT_MODEL_FNAME,
@@ -24,8 +24,6 @@ from keys_values.data.base import (
 from keys_values.data.evaluation import ORIG_IDX_NAME, TASK_NAME
 
 EVAL_METRICS_FNAME = "eval/eval_metrics_{}.csv"
-
-EVAL_METRICS_GLOB = EVAL_METRICS_FNAME.replace("{}", "*")
 
 REGEX_TASKNAME = re.compile(r"step-[0-9]{6}|final")
 
@@ -57,12 +55,17 @@ class EvaluationTasks:
         model_type: str,
         tasks: Optional[List[str]] = None,
         collect_results: bool = False,
+        eval_metrics_filename: Optional[str] = None,
     ):
         if isinstance(out_dir, str):
             out_dir = Path(out_dir)
         self._out_dir = out_dir
         self.model_type = model_type
         self._tasks = tasks.copy() if tasks is not None else None
+        if eval_metrics_filename is None:
+            eval_metrics_filename = EVAL_METRICS_FNAME
+        self._eval_metrics_filename = eval_metrics_filename
+        self._eval_metrics_glob = eval_metrics_filename.replace("{}", "*")
         self._init_task_names(collect_results)
 
     def _init_task_names(self, collect_results: bool):
@@ -100,9 +103,8 @@ class EvaluationTasks:
                 elif self._num_result_files(path) == 0:
                     raise ValueError(f"{path} contains no evaluation result files")
 
-    @staticmethod
-    def _num_result_files(path: Path) -> int:
-        return len(list(path.glob(EVAL_METRICS_GLOB)))
+    def _num_result_files(self, path: Path) -> int:
+        return len(list(path.glob(self._eval_metrics_glob)))
 
     @property
     def tasks(self) -> List[str]:
@@ -127,24 +129,26 @@ class EvaluationTasks:
 
     def eval_result_files(
         self,
-        return_incompletes: bool = False,
+        mode: Literal["non-lock", "lock", "all"] = "non-lock",
     ) -> Iterable[Tuple[str, List[Path]]]:
         """
         Args:
-            return_incompletes: If `True`, we return the complete lock files.
-                Defaults to `False`, so lock files are filtered out.
+            mode: For "non-lock", we return complete files (not locks). For
+                "lock", we return incomplete lock files. For "all", we
+                return all files.
         Yields:
             `(task_name, result_file_paths)`, where `result_file_paths`
             is list of paths of evaluation result files for this task name.
-            These files are filtered to not contain incomplete lock files.
-            But if `return_incompletes == True`, only incomplete files are
-            returned.
+            This list is filtered depending on `mode`.
 
         """
+        choices = ("non-lock", "lock", "all")
+        if mode not in choices:
+            raise ValueError(f"Invalid mode = {mode}, must be in {choices}")
         for task_name in self._tasks:
             result_file_paths = self._filter_incomplete_files(
-                (self._out_dir / task_name).glob(EVAL_METRICS_GLOB),
-                return_incompletes=return_incompletes,
+                (self._out_dir / task_name).glob(self._eval_metrics_glob),
+                mode=mode,
             )
             if result_file_paths:
                 yield task_name, result_file_paths
@@ -152,12 +156,17 @@ class EvaluationTasks:
     @staticmethod
     def _filter_incomplete_files(
         paths: Iterable[Path],
-        return_incompletes: bool = False,
+        mode: Literal["non-lock", "lock", "all"],
     ) -> List[Path]:
         result = []
+        return_all = mode == "all"
+        return_incompletes = mode == "lock"
         for path in paths:
             with path.open("r") as fp:
-                if fp.readline().startswith(FILE_LOCK_TEXT) == return_incompletes:
+                if (
+                    return_all
+                    or fp.readline().startswith(FILE_LOCK_TEXT) == return_incompletes
+                ):
                     result.append(path)
         return result
 
@@ -172,11 +181,19 @@ class EvaluationWithTasksHelper:
     dataloader we use.
     """
 
-    def __init__(self, out_dir: Path, tag: Optional[str] = None):
+    def __init__(
+        self,
+        out_dir: Path,
+        tag: Optional[str] = None,
+        eval_metrics_filename: Optional[str] = None,
+    ):
         self._out_dir = out_dir
         if tag is None:
             tag = ""
         self._tag = tag
+        if eval_metrics_filename is None:
+            eval_metrics_filename = EVAL_METRICS_FNAME
+        self._eval_metrics_filename = eval_metrics_filename
 
     def evaluation_metrics_path(self, batch: Dict[str, Any]) -> Path:
         """
@@ -197,7 +214,7 @@ class EvaluationWithTasksHelper:
                 f"batch[{TASK_NAME}] = {task}."
             )
         suffix = self._tag + str(orig_idxs[0])
-        fname = EVAL_METRICS_FNAME.format(suffix)
+        fname = self._eval_metrics_filename.format(suffix)
         return self._out_dir / task / fname
 
     def get_lock(self, batch: Dict[str, Any]) -> Optional[Path]:

--- a/keys_values/finetune/longcontext_eval.py
+++ b/keys_values/finetune/longcontext_eval.py
@@ -36,6 +36,8 @@ def setup(
     use_sample_metric: bool = True,
     sample_metric_max_generated_tokens: int = 20,
     sample_metric_kwargs: Optional[Dict[str, Any]] = None,
+    num_store_generated_samples: Optional[int] = None,
+    skip_eval: bool = False,
 ) -> None:
     """Evaluate a range of model checkpoints on a test set
 
@@ -101,6 +103,15 @@ def setup(
             for sample-based metric evaluation
         sample_metric_kwargs: Keyword arguments for token sampling (params
             can be "temperature", "top_k", "top_p")
+        num_store_generated_samples: If given and positive, we write files
+            containing the generated sequences along with SFT targets and raw
+            targets. These files are written alongside metric files, using the
+            same naming convention. They are written for the initial test set
+            batches, until `num_store_generated_samples` cases are covered
+            (rounded up to a multiple of `batch_size`). Must have
+            `use_sample_metric == True`.
+        skip_eval: If `True`, we skip evaluations and only write files related
+            to `num_store_generated_samples`.
 
     """
     entry = {
@@ -124,4 +135,6 @@ def setup(
         use_sample_metric=use_sample_metric,
         sample_metric_max_generated_tokens=sample_metric_max_generated_tokens,
         sample_metric_kwargs=sample_metric_kwargs,
+        num_store_generated_samples=num_store_generated_samples,
+        skip_eval=skip_eval,
     )

--- a/keys_values/finetune/longcontext_eval_ext.py
+++ b/keys_values/finetune/longcontext_eval_ext.py
@@ -17,11 +17,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from pprint import pprint
 from typing import Dict, Optional, Union, Any, List, Tuple
+import yaml
 
 import lightning as L
 import torch
 from lightning.fabric.strategies import DDPStrategy
-import yaml
 
 from litgpt.data import DataModule
 from litgpt.tokenizer import Tokenizer
@@ -44,7 +44,10 @@ from keys_values.data.base import (
     LORA_WEIGHTS_FNAME,
     LORA_WEIGHTS_FNAME_OLD,
 )
-from keys_values.evaluation.evaluator import SampleBasedMetricsEvaluator
+from keys_values.evaluation.evaluator import (
+    SampleBasedMetricsEvaluator,
+    TargetType,
+)
 from keys_values.evaluation.tasks import (
     EvaluationTasks,
     EvaluationWithTasksHelper,
@@ -81,6 +84,8 @@ from keys_values.utils import (
     fabric_precision_to_dtype,
     remove_keys,
 )
+
+GENERATED_SAMPLES_FILENAME = "generated_samples_{}.yaml"
 
 
 @dataclass
@@ -126,6 +131,8 @@ def setup(
     use_sample_metric: bool = True,
     sample_metric_max_generated_tokens: int = 20,
     sample_metric_kwargs: Optional[Dict[str, Any]] = None,
+    num_store_generated_samples: Optional[int] = None,
+    skip_eval: bool = False,
 ) -> None:
     """Evaluate a range of checkpoints for several models on a test set
 
@@ -162,6 +169,15 @@ def setup(
             for sample-based metric evaluation
         sample_metric_kwargs: Keyword arguments for token sampling (params
             can be "temperature", "top_k", "top_p")
+        num_store_generated_samples: If given and positive, we write files
+            containing the generated sequences along with SFT targets and raw
+            targets. These files are written alongside metric files, using the
+            same naming convention. They are written for the initial test set
+            batches, until `num_store_generated_samples` cases are covered
+            (rounded up to a multiple of `batch_size`). Must have
+            `use_sample_metric == True`.
+        skip_eval: If `True`, we skip evaluations and only write files related
+            to `num_store_generated_samples`.
 
     """
     devices = parse_devices(devices)
@@ -193,6 +209,8 @@ def setup(
         use_sample_metric,
         sample_metric_max_generated_tokens,
         sample_metric_kwargs,
+        num_store_generated_samples,
+        skip_eval,
     )
 
 
@@ -208,7 +226,22 @@ def setup_internal(
     use_sample_metric: bool,
     sample_metric_max_generated_tokens: int,
     sample_metric_kwargs: Optional[Dict[str, Any]],
+    num_store_generated_samples: Optional[int],
+    skip_eval: bool,
 ) -> None:
+    if num_store_generated_samples is None and skip_eval:
+        raise ValueError(
+            "If skip_eval is True, num_store_generated_samples must be given"
+        )
+    if num_store_generated_samples is not None:
+        if num_store_generated_samples <= 0:
+            raise ValueError(
+                f"num_store_generated_samples = {num_store_generated_samples}, must be positive"
+            )
+        if not use_sample_metric:
+            raise ValueError(
+                f"num_store_generated_samples can only be used if use_sample_metric is True"
+            )
     # Need to obtain `precision` from hyperparameters of first setup
     out_dir = Path(setups[0]["out_dir"])
     model_type = setups[0]["model_type"]
@@ -248,6 +281,8 @@ def setup_internal(
         sample_metric_kwargs=sample_metric_kwargs,
         lora_dropout=lora_dropout,
         access_token=access_token,
+        num_store_generated_samples=num_store_generated_samples,
+        skip_eval=skip_eval,
     )
 
 
@@ -264,6 +299,8 @@ def main(
     sample_metric_kwargs: Dict[str, Any],
     lora_dropout: Optional[float],
     access_token: Optional[str],
+    num_store_generated_samples: Optional[int],
+    skip_eval: bool,
 ) -> None:
     fabric.seed_everything(seed)
 
@@ -388,7 +425,6 @@ def main(
         set_fused_swiglu_enabled(sdpa.fused_swiglu)
 
         # Create model
-        is_lora = model_type == "lora"
         if torch.cuda.is_available():
             device = torch.device("cuda", fabric.local_rank)
         else:
@@ -440,6 +476,20 @@ def main(
             load_checkpoint(fabric, model.head_model, file_path, strict=True)
 
         # Evaluation over tasks and batches
+        # `num_store_generated_batches` is the number of batches for which
+        # generated samples are written out
+        if num_store_generated_samples is not None:
+            num_store_generated_batches = (
+                num_store_generated_samples // batch_size
+                + int(num_store_generated_samples % batch_size > 0)
+            )
+            if devices > 1:
+                num_store_generated_batches = (
+                    num_store_generated_batches // devices
+                    + int(fabric.local_rank < num_store_generated_batches % devices)
+                )
+        else:
+            num_store_generated_batches = None
         eval_for_setup(
             fabric,
             model,
@@ -454,6 +504,8 @@ def main(
             use_sample_metric,
             sample_metric_max_generated_tokens,
             sample_metric_kwargs,
+            num_store_generated_batches,
+            skip_eval,
         )
 
 
@@ -471,9 +523,11 @@ def eval_for_setup(
     use_sample_metric: bool,
     sample_metric_max_generated_tokens,
     sample_metric_kwargs: Dict[str, Any],
+    num_store_generated_batches: Optional[int],
+    skip_eval: bool,
 ) -> None:
-    # Test dataloader is over cross product of test dataset and evaluation
-    # tasks
+    # Test dataloader is over cross product of test dataset batches and
+    # evaluation tasks
     test_dataloader = get_dataloader(
         data=data,
         tokenizer=tokenizer,
@@ -511,6 +565,8 @@ def eval_for_setup(
         model_type,
         model_config,
         devices,
+        num_store_generated_batches,
+        skip_eval,
         ignore_index,
     )
 
@@ -526,6 +582,8 @@ def eval_for_setup_internal(
     model_type: str,
     model_config: ModelConfiguration,
     devices: int,
+    num_store_generated_batches: Optional[int],
+    skip_eval: bool,
     ignore_index: int = -100,
 ) -> None:
     # Loop over test set batches
@@ -542,18 +600,44 @@ def eval_for_setup_internal(
         tag = data.test_set_tag
     else:
         tag = None
-    tasks_helper = EvaluationWithTasksHelper(out_dir, tag)
+    # Note: If `skip_eval == True`, we assume that the eval metrics files are
+    # already present, and we use the generated samples files for locking
+    if skip_eval:
+        fname = "eval/" + GENERATED_SAMPLES_FILENAME
+    else:
+        fname = None
+    tasks_helper = EvaluationWithTasksHelper(
+        out_dir,
+        tag=tag,
+        eval_metrics_filename=fname,
+    )
     current_task = None
     test_dataiter = iter(test_dataloader)
     if devices > 1:
         # Ensure that lock for first batch is not checked at exactly the same
         # time by all devices
         time.sleep(0.05 * fabric.global_rank)
+    batch_idx = 0  # Batch counter per task
+    skip_until_next_task = False
     for batch in test_dataiter:
         if not batch:
             print("Empty batch: Continue")
             continue
+        if skip_until_next_task:
+            if batch[TASK_NAME] == current_task:
+                continue
+            skip_until_next_task = False
+        store_generated_batch = (
+            num_store_generated_batches is not None
+            and batch_idx < num_store_generated_batches
+        )
         task = batch[TASK_NAME]
+        if skip_eval and not store_generated_batch and task == current_task:
+            print(
+                f"Wrote out generated samples for {num_store_generated_batches} batches: Skipping remaining ones for this task"
+            )
+            skip_until_next_task = True
+            continue
         orig_idxs = batch[ORIG_IDX_NAME]
         eval_metrics_path = tasks_helper.get_lock(batch)
         if eval_metrics_path is None:
@@ -578,6 +662,7 @@ def eval_for_setup_internal(
                     fabric=fabric,
                 )
                 current_task = task
+                batch_idx = 0  # Reset
 
             t0 = time.perf_counter()
             # One entry per batch dimension:
@@ -587,20 +672,54 @@ def eval_for_setup_internal(
                 with torch.no_grad():
                     metric_values = model(input_ids, targets)
                 metric_name = "eval_loss"
+                generated_samples = None
+                raw_targets = None
             else:
                 metric_name = evaluator.metrics[0]
                 prompt_len = input_ids.shape[1] - targets.shape[1] + 1
                 prompts = input_ids[:, :prompt_len]
                 raw_targets = batch[TARGETS_STRINGS_NAME]
-                metric_values = evaluator(model, prompts, raw_targets)[metric_name]
+                metric_values, generated_samples = evaluator(
+                    model,
+                    prompts,
+                    raw_targets,
+                    return_samples=store_generated_batch,
+                )
+                metric_values = metric_values[metric_name]
             eval_time = time.perf_counter() - t0
             print_with_rank_and_timestamp(
                 f"Batch {task}, {orig_idxs}: {metric_name} = {metric_values.mean().item():.3f}, eval_time = {eval_time * 1000:.2f} ms",
                 fabric.global_rank,
             )
             flush_io_streams()
-            print(f"Storing to {eval_metrics_path}")
-            store_eval_metrics(metric_name, metric_values, batch, eval_metrics_path)
+            if not skip_eval:
+                print(f"Storing to {eval_metrics_path}")
+                store_eval_metrics(metric_name, metric_values, batch, eval_metrics_path)
+            if store_generated_batch:
+                if skip_eval:
+                    result_path = eval_metrics_path
+                else:
+                    eval_fname = eval_metrics_path.stem
+                    suffix = "_".split(eval_fname)[-1]
+                    result_path = (
+                        eval_metrics_path.parent
+                        / GENERATED_SAMPLES_FILENAME.format(suffix)
+                    )
+                print(f"Storing generated samples to {result_path}")
+                store_generated_samples(
+                    metric_name=metric_name,
+                    metric_values=metric_values,
+                    batch=batch,
+                    generated_samples=generated_samples,
+                    targets=targets,
+                    raw_targets=raw_targets,
+                    tokenizer=tokenizer,
+                    result_path=result_path,
+                    ignore_index=ignore_index,
+                )
+            # Only count a batch if it was not skipped:
+            batch_idx += 1
+
         except Exception as ex:
             print("Caught exception during evaluation:\n" + str(ex))
             eval_metrics_path.unlink(missing_ok=True)
@@ -614,7 +733,7 @@ def get_dataloader(
     head_model: str,
     batch_size: int,
     devices: int,
-    fabric: Optional[L.Fabric] = None,
+    fabric: Optional[L.Fabric],
 ) -> EvaluationDataLoader:
     """
     Creates data loader for cross product of test dataset with evaluation
@@ -737,3 +856,34 @@ def store_eval_metrics(
         writer.writerow(fieldnames)
         for idx, loss in zip(batch[ORIG_IDX_NAME], metric_values):
             writer.writerow([idx, task, loss.item()])
+
+
+def store_generated_samples(
+    metric_name: str,
+    metric_values: torch.Tensor,
+    batch: dict[str, Any],
+    generated_samples: List[str],
+    targets: torch.Tensor,
+    raw_targets: List[TargetType],
+    tokenizer: Tokenizer,
+    result_path: Path,
+    ignore_index: int,
+):
+    entries = [
+        {
+            "idx": idx,
+            metric_name: metric_val.item(),
+            "output": output,
+            "raw_target": raw_target,
+            "sft_target": tokenizer.decode(target[target != ignore_index]),
+        }
+        for idx, metric_val, output, raw_target, target in zip(
+            batch[ORIG_IDX_NAME],
+            metric_values,
+            generated_samples,
+            raw_targets,
+            targets,
+        )
+    ]
+    with result_path.open("w") as fp:
+        yaml.safe_dump(entries, fp)

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -1900,7 +1900,7 @@ def validate_sample_metric(
         raw_targets = batch[TARGETS_STRINGS_NAME]
         prompt_len = input_ids.shape[1] - batch["targets"].shape[1] + 1
         prompts = input_ids[:, :prompt_len]
-        metric_vals = evaluator(model, prompts, raw_targets)
+        metric_vals = evaluator(model, prompts, raw_targets)[0]
         sum_metric_values += metric_vals[evaluator.metrics[0]].sum().item()
         num_entries += 1
     model.train()

--- a/keys_values/scripts/cleanup_evaluation.py
+++ b/keys_values/scripts/cleanup_evaluation.py
@@ -11,31 +11,57 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from itertools import product
 from pathlib import Path
+from typing import Literal
 
 from keys_values.evaluation.tasks import EvaluationTasks
 
 
-def main(out_dir: Path, model_type: str):
+def main(
+    out_dir: Path,
+    model_type: str,
+    mode: Literal["non-lock", "lock", "all"],
+):
     total_removed = 0
     eval_tasks = EvaluationTasks(out_dir, model_type)
-    for task_name, incomplete_file_paths in eval_tasks.eval_result_files(
-        return_incompletes=True,
-    ):
-        print(f"{task_name}: Removing {len(incomplete_file_paths)} lock files")
+    print(f"Removing files for {out_dir}")
+    for task_name, incomplete_file_paths in eval_tasks.eval_result_files(mode):
+        print(f"{task_name}: Removing {len(incomplete_file_paths)} files (type {mode})")
         for path in incomplete_file_paths:
             path.unlink()
         total_removed += len(incomplete_file_paths)
-    print(f"\nRemoved {total_removed} lock files in total")
+    print(f"Removed {total_removed} files in total (type {mode})")
 
 
 if __name__ == "__main__":
     base_path = Path.home() / "out/finetune/neurips_exp/lora/qwen3_4b"
-    out_dirs = [
-        "helmet_nq_64k/slr_4gpu_cs2048_lr5",
-        "helmet_trivia_qa_64k/lr_4gpu_cs2048_lr5",
-        "helmet_trivia_qa_64k/h2o_4gpu_cs2048_lr5",
+    # dataset_size = "64k"
+    dataset_size = "128k"
+    datasets = [
+        f"helmet_nq_{dataset_size}",
+        f"helmet_trivia_qa_{dataset_size}",
+        f"helmet_hotpot_qa_{dataset_size}",
+        f"helmet_pop_qa_{dataset_size}",
     ]
+    cases = [
+        "lr_4gpu_cs2048_lr5",
+        "lr_4gpu_cs1024_lr5",
+        "slr_4gpu_cs2048_lr5",
+        "h2o_4gpu_cs2048_lr5",
+        "qh2o_4gpu_cs2048_lr5",
+        "h2onorm_4gpu_cs2048_lr5",
+        "qh2onorm_4gpu_cs2048_lr5",
+        "h2o_4gpu_cs1024_lr5",
+    ]
+    # Use this to clean up lock files before restarting evaluation
+    # mode = "lock"
+    # Use this to remove all evaluation files
+    mode: Literal["non-lock", "lock", "all"] = "all"
     model_type = "lora"
-    for out_dir in out_dirs:
-        main(base_path / out_dir, model_type)
+    for dataset, case in product(datasets, cases):
+        out_dir = base_path / dataset / case
+        if out_dir.exists():
+            main(out_dir, model_type, mode)
+        else:
+            print(f"\nResults for {dataset}/{case} do not exist")

--- a/keys_values/scripts/cleanup_gen_samples.py
+++ b/keys_values/scripts/cleanup_gen_samples.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+import yaml
+
+from keys_values.finetune.longcontext_eval_ext import GENERATED_SAMPLES_FILENAME
+
+
+def main(control_file: Path):
+    setups = yaml.safe_load(control_file.open())
+    num_total = 0
+    for setup in setups:
+        for task in setup["eval_tasks"]:
+            num_task = 0
+            base_path = Path(setup["out_dir"]) / task / "eval"
+            for path in base_path.glob(GENERATED_SAMPLES_FILENAME.replace("{}", "*")):
+                path.unlink()
+                num_task += 1
+            if num_task > 0:
+                print(f"Removed {num_task} files from {base_path}")
+            num_total += num_task
+    print(f"\nRemoved {num_total} generated samples files in total")
+
+
+if __name__ == "__main__":
+    # dataset_size = "64k"
+    dataset_size = "128k"
+    control_file = (
+        Path.home() / "sync" / "keys_values" / f"eval_inst1_{dataset_size}.yaml"
+    )
+    # control_file = Path.home() / "git" / "keys_values" / f"eval_inst2_3_{dataset_size}.yaml"
+    main(control_file)

--- a/keys_values/scripts/collect_gen_samples.py
+++ b/keys_values/scripts/collect_gen_samples.py
@@ -11,16 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import csv
 from itertools import product
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
+import yaml
 
 from keys_values.evaluation.tasks import EvaluationTasks
+from keys_values.finetune.longcontext_eval_ext import GENERATED_SAMPLES_FILENAME
 
-EVAL_METRICS_ALL_FILENAME = "eval_metrics_all.csv"
+GENERATED_SAMPLES_ALL_FILENAME = "generated_samples_all.yaml"
 
-SWEEP_TAR_FILENAME = "eval_metrics_transfer_{dataset_size}.tgz"
+SWEEP_TAR_FILENAME = "generated_samples_transfer_{dataset_size}.tgz"
 
 
 def main(
@@ -29,41 +30,34 @@ def main(
     tasks: Optional[List[str]] = None,
 ):
     # Collect results from all files across all tasks
-    print(f"\nLoading evaluation result files from {out_dir}")
+    print(f"\nLoading generated samples files from {out_dir}")
     eval_tasks = EvaluationTasks(
         out_dir,
         model_type,
         tasks,
         collect_results=True,
+        eval_metrics_filename="eval/" + GENERATED_SAMPLES_FILENAME,
     )
-    all_data = []
-    column_names = None
+    all_data: Dict[str, List[Dict[str, Any]]] = dict()
+    num_total = 0
     for task_name, result_file_paths in eval_tasks.eval_result_files():
         print(f"{task_name}: {len(result_file_paths)}")
-        sum_vals = 0
-        num_vals = 0
+        records: List[Dict[str, Any]] = []
         for path in result_file_paths:
-            with open(path, "r") as fp:
-                reader = csv.reader(fp, delimiter=",")
-                first_row = True
-                for row in reader:
-                    if not first_row:
-                        all_data.append(row)
-                        sum_vals += float(row[-1])
-                        num_vals += 1
-                    elif column_names is None:
-                        column_names = row
-                    first_row = False
-        print(f"    {column_names[-1]} = {(sum_vals / num_vals):.3f}")
+            records.extend(yaml.safe_load(path.open()))
+        print(f"    {len(records)} records")
+        num_total += len(records)
+        records = sorted(
+            records,
+            key=lambda x: (x["sub_exact_match"], x["idx"]),
+        )
+        all_data[task_name] = records
 
-    print(f"Total number of records: {len(all_data)}")
+    print(f"Total number of records: {num_total}")
     if all_data:
-        combined_path = out_dir / EVAL_METRICS_ALL_FILENAME
+        combined_path = out_dir / GENERATED_SAMPLES_ALL_FILENAME
         with open(combined_path, "w") as fp:
-            writer = csv.writer(fp, delimiter=",")
-            writer.writerow(column_names)
-            for row in sorted(all_data, key=lambda x: (x[1], int(x[0]))):
-                writer.writerow(row)
+            yaml.safe_dump(all_data, fp)
 
 
 if __name__ == "__main__":
@@ -100,7 +94,7 @@ if __name__ == "__main__":
     elif mode == "sweep":
         names = []
         for dataset, case in product(datasets, cases):
-            name = "/".join((dataset, case, EVAL_METRICS_ALL_FILENAME))
+            name = "/".join((dataset, case, GENERATED_SAMPLES_ALL_FILENAME))
             if (base_path / name).exists():
                 names.append(name)
         print(


### PR DESCRIPTION
We allow to store the generated samples used to compute metric values, along with targets and raw targets:

- Useful for debugging performance, getting example outputs
- Can also store all samples and evaluate other metrics posthoc

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
