### PR TITLE
Add chunked log-prob computation for TRL GRPO integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ logs/
 out/
 checkpoints/
 test_tokenizer/
+keyval_venv/

--- a/ai_dev/trl_integration.md
+++ b/ai_dev/trl_integration.md
@@ -1,0 +1,6 @@
+# TRL Integration - AI Development Notes
+
+## AI Usage
+
+AI was used to generate docstrings for the functions and classes in
+`keys_values/logprobs.py` and `keys_values/finetune/grpo.py`.

--- a/keys_values/finetune/grpo.py
+++ b/keys_values/finetune/grpo.py
@@ -32,6 +32,7 @@ Usage::
     )
     trainer.train()
 """
+
 from __future__ import annotations
 
 import torch
@@ -127,6 +128,7 @@ class GRPOLongContextTrainer(GRPOTrainer):
             else None
         )
         return logps, entropies
+
 
 def _unwrap(model) -> GPT:
     """Peel wrappers (DDP, PEFT, HF, ...) until we hit a ``GPT`` instance."""

--- a/keys_values/finetune/grpo.py
+++ b/keys_values/finetune/grpo.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+GRPO fine-tuning with KeysAndValues long-context KV cache support.
+
+Provides ``GRPOLongContextTrainer`` — a subclass of TRL's ``GRPOTrainer``
+whose per-token log-probability computation uses KeysAndValues' chunked
+KV-cache forward pass, bounding GPU memory for arbitrarily long sequences.
+
+Usage::
+
+    from keys_values.finetune.grpo import GRPOLongContextTrainer
+
+    trainer = GRPOLongContextTrainer(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        reward_funcs=my_reward_func,
+        train_dataset=dataset,
+        kv_cache_name="h2o-torch-quantized8",
+        kv_cache_length=16384,
+        kv_chunk_size=1024,
+    )
+    trainer.train()
+"""
+from __future__ import annotations
+
+import torch
+from trl.trainer.grpo_trainer import GRPOTrainer
+
+from keys_values.logprobs import chunked_per_token_logps
+from keys_values.model import GPT
+
+_UNWRAP_ATTRS = ("gpt_model", "model", "base_model", "module")
+
+
+class GRPOLongContextTrainer(GRPOTrainer):
+    """``GRPOTrainer`` with KV-cache chunked log-prob computation.
+
+    Overrides TRL's full-sequence forward with KeysAndValues' bounded-memory
+    chunked path for sequences exceeding ``kv_cache_length``. Short sequences
+    fall through to TRL's default — zero overhead.
+
+    Parameters
+    ----------
+    kv_cache_name : str
+        Cache policy, e.g. ``"h2o-torch-quantized8"``.
+    kv_cache_length : int
+        Slot count. Sequences longer than this trigger the chunked path.
+    kv_chunk_size : int
+        Chunk size for post-prefill processing.
+    kv_cache_kwargs : dict | None
+        Extra kwargs forwarded to ``KVCacheFactory.create``.
+    """
+
+    def __init__(
+        self,
+        *args,
+        kv_cache_name: str = "h2o-torch-quantized8",
+        kv_cache_length: int = 16384,
+        kv_chunk_size: int = 1024,
+        kv_cache_kwargs: dict | None = None,
+        **kwargs,
+    ):
+        self.kv_cache_name = kv_cache_name
+        self.kv_cache_length = kv_cache_length
+        self.kv_chunk_size = kv_chunk_size
+        self.kv_cache_kwargs = kv_cache_kwargs
+        super().__init__(*args, **kwargs)
+
+    def _get_per_token_logps_and_entropies(
+        self,
+        model,
+        input_ids,
+        attention_mask,
+        logits_to_keep,
+        *,
+        batch_size=None,
+        compute_entropy=False,
+        **kwargs,
+    ):
+        """Route long sequences through the chunked KV-cache path."""
+        seq_len = input_ids.shape[1]
+
+        if seq_len <= self.kv_cache_length:
+            return super()._get_per_token_logps_and_entropies(
+                model,
+                input_ids,
+                attention_mask,
+                logits_to_keep,
+                batch_size=batch_size,
+                compute_entropy=compute_entropy,
+                **kwargs,
+            )
+
+        gpt = _unwrap(model)
+        bs = batch_size or input_ids.size(0)
+
+        results = [
+            chunked_per_token_logps(
+                gpt_model=gpt,
+                input_ids=input_ids[i : i + bs],
+                logits_to_keep=logits_to_keep,
+                cache_name=self.kv_cache_name,
+                cache_length=self.kv_cache_length,
+                chunk_size=self.kv_chunk_size,
+                cache_kwargs=self.kv_cache_kwargs,
+                temperature=self.temperature,
+                compute_entropy=compute_entropy,
+            )
+            for i in range(0, input_ids.size(0), bs)
+        ]
+
+        logps = torch.cat([r[0] for r in results])
+        entropies = (
+            torch.cat([r[1] for r in results if r[1] is not None])
+            if results[0][1] is not None
+            else None
+        )
+        return logps, entropies
+
+def _unwrap(model) -> GPT:
+    """Peel wrappers (DDP, PEFT, HF, ...) until we hit a ``GPT`` instance."""
+    seen: set[int] = set()
+    cur = model
+    while not isinstance(cur, GPT):
+        if id(cur) in seen:
+            break
+        seen.add(id(cur))
+        nxt = next(
+            (getattr(cur, a) for a in _UNWRAP_ATTRS if hasattr(cur, a)),
+            None,
+        )
+        if nxt is None:
+            break
+        cur = nxt
+
+    if not isinstance(cur, GPT):
+        raise TypeError(
+            f"Cannot locate a keys_values.model.GPT inside {type(model).__name__}. "
+            "Ensure your model was loaded through keys_values."
+        )
+    return cur

--- a/keys_values/logprobs.py
+++ b/keys_values/logprobs.py
@@ -32,6 +32,7 @@ Usage::
         chunk_size=1024,
     )
 """
+
 from typing import Optional, Tuple
 
 import torch
@@ -59,8 +60,9 @@ class LogProbsHeadModel(HeadModel):
 
     NAME = "log_probs"
 
-    def __init__(self, config: Config, temperature: float = 1.0,
-                 compute_entropy: bool = False):
+    def __init__(
+        self, config: Config, temperature: float = 1.0, compute_entropy: bool = False
+    ):
         super().__init__()
         self._vocab_size = config.padded_vocab_size
         self._temperature = temperature
@@ -129,9 +131,7 @@ class LogProbsHeadModel(HeadModel):
         """
         logps = torch.cat(self._logps_chunks, dim=1)
         entropies = (
-            torch.cat(self._entropy_chunks, dim=1)
-            if self._entropy_chunks
-            else None
+            torch.cat(self._entropy_chunks, dim=1) if self._entropy_chunks else None
         )
         return logps, entropies
 
@@ -207,7 +207,7 @@ def compute_logprobs(
         chunk_size=chunk_size,
     )
 
-    # Run the forward pass 
+    # Run the forward pass
     inference_model(input_ids=input_ids, targets=targets)
 
     logps, entropies = head.get_results()

--- a/keys_values/logprobs.py
+++ b/keys_values/logprobs.py
@@ -14,39 +14,141 @@
 """
 Memory-efficient per-token log-probability computation using KV cache.
 
-This module provides :func:`chunked_per_token_logps`, which computes
-per-token log-probabilities using KeysAndValues' chunked forward pass
-with a KV cache policy. Instead of materializing the full
-``(batch, seq_length, vocab_size)`` logits tensor, it processes the
-sequence in chunks and extracts log-probs incrementally.
+Implements a :class:`HeadModel` that accumulates per-token log-probs
+(and optionally entropies) instead of a scalar loss. Plug it into
+:class:`LongContextInferenceModel` and the existing chunked forward
+infrastructure handles everything — no new forward loop needed.
 
-Memory usage is bounded by ``O(batch * chunk_size * vocab_size)``
-regardless of total sequence length.
+Usage::
 
-For TRL integration, see :class:`keys_values.finetune.grpo.GRPOLongContextTrainer`.
+    from keys_values.logprobs import compute_logprobs
+
+    logps, entropies = compute_logprobs(
+        gpt_model=model,
+        input_ids=input_ids,
+        targets=completion_ids,
+        cache_name="h2o-torch-quantized8",
+        cache_length=16384,
+        chunk_size=1024,
+    )
 """
 from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 
-from keys_values.kvcache.factory import (
-    KVCacheFactory,
-    deallocate_kv_cache_buffers_of_model,
-)
-from keys_values.kvcache.stack_layers import DefaultCellBlocks
-from keys_values.long_context import (
-    create_chunk_sizes,
-    get_chunks_for_cells,
-    write_back_cache_buffers,
-)
+from keys_values.config import Config
+from keys_values.head_model import HeadModel
+from keys_values.kvcache.factory import KVCacheFactory
+from keys_values.long_context import LongContextInferenceModel
 from keys_values.model import GPT
 
 
-def chunked_per_token_logps(
+class LogProbsHeadModel(HeadModel):
+    """HeadModel that accumulates per-token log-probs instead of a loss.
+
+    Wraps the same logic as :class:`CrossEntropyOnLogits` but instead of
+    reducing to a scalar loss, it gathers the log-probability of each target
+    token and stores it. After the full chunked forward pass completes,
+    call :meth:`get_results` to retrieve the accumulated tensors.
+
+    This is meant to be used with :class:`LongContextInferenceModel` — the
+    existing chunk/cell/layer loop calls ``forward()`` chunk by chunk, and
+    this class collects log-probs as they come.
+    """
+
+    NAME = "log_probs"
+
+    def __init__(self, config: Config, temperature: float = 1.0,
+                 compute_entropy: bool = False):
+        super().__init__()
+        self._vocab_size = config.padded_vocab_size
+        self._temperature = temperature
+        self._compute_entropy = compute_entropy
+        self._logps_chunks: list[torch.Tensor] = []
+        self._entropy_chunks: list[torch.Tensor] = []
+
+    def needs_logits(self) -> bool:
+        return True
+
+    def forward(
+        self,
+        model_outputs: torch.Tensor,
+        targets: Optional[torch.Tensor],
+        input_pos: int,
+    ) -> torch.Tensor:
+        """Accumulate log-probs for target tokens in this chunk.
+
+        Called by LongContextInferenceModel for each chunk. When targets
+        is None (prompt-only chunk), we skip. When targets are present,
+        we gather log-probs and optionally entropy.
+        """
+        if input_pos == 0:
+            self._logps_chunks.clear()
+            self._entropy_chunks.clear()
+
+        diff = self._check_model_outputs_targets(
+            model_outputs, targets, final_dim=self._vocab_size
+        )
+
+        if diff is not None:
+            logits = model_outputs[:, diff:, :]
+            if self._temperature != 1.0:
+                logits = logits / self._temperature
+
+            # Per-token log-probs
+            log_probs = F.log_softmax(logits, dim=-1)
+            token_logps = torch.gather(
+                log_probs, dim=-1, index=targets.unsqueeze(-1)
+            ).squeeze(-1)
+            self._logps_chunks.append(token_logps)
+
+            if self._compute_entropy:
+                ent = -(log_probs.exp() * log_probs).sum(dim=-1)
+                self._entropy_chunks.append(ent)
+
+        # Return zeros
+        return torch.zeros(
+            model_outputs.shape[0],
+            device=model_outputs.device,
+            dtype=model_outputs.dtype,
+        )
+
+    def num_target_entries(self, targets: torch.Tensor) -> Optional[torch.Tensor]:
+        return None
+
+    def get_results(self) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Retrieve accumulated log-probs and entropies after forward pass.
+
+        Returns
+        -------
+        logps : torch.Tensor
+            Shape ``(batch_size, num_target_tokens)``.
+        entropies : torch.Tensor | None
+            Shape ``(batch_size, num_target_tokens)`` or None.
+        """
+        logps = torch.cat(self._logps_chunks, dim=1)
+        entropies = (
+            torch.cat(self._entropy_chunks, dim=1)
+            if self._entropy_chunks
+            else None
+        )
+        return logps, entropies
+
+    def _empty_clone(self, device: Optional[torch.device] = None) -> "HeadModel":
+        config = Config()
+        config.padded_vocab_size = self._vocab_size
+        return LogProbsHeadModel(
+            config,
+            temperature=self._temperature,
+            compute_entropy=self._compute_entropy,
+        )
+
+
+def compute_logprobs(
     gpt_model: GPT,
     input_ids: torch.Tensor,
-    logits_to_keep: int,
+    targets: torch.Tensor,
     cache_name: str = "h2o-torch-quantized8",
     cache_length: int = 16384,
     chunk_size: int = 1024,
@@ -54,189 +156,66 @@ def chunked_per_token_logps(
     temperature: float = 1.0,
     compute_entropy: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-    """Compute per-token log-probs using chunked KV-cache forward pass.
+    """Compute per-token log-probs via LongContextInferenceModel.
 
-    This is the KeysAndValues alternative to TRL's full-sequence forward.
-    It processes ``input_ids`` chunk by chunk through the model with a KV
-    cache active, only materializing logits for one chunk at a time. For
-    positions corresponding to completion tokens (the last ``logits_to_keep``
-    positions), it extracts log-probs on the fly.
-
-    Memory usage is bounded by ``O(batch * chunk_size * vocab_size)`` for
-    the logits tensor, regardless of total sequence length.
+    This is the primary entry point. It creates a :class:`LogProbsHeadModel`,
+    plugs it into :class:`LongContextInferenceModel`, and runs the existing
+    chunked forward pass. All KV cache management, chunk/cell grouping, and
+    layer processing is handled by the existing infrastructure.
 
     Args:
-        gpt_model: A KeysAndValues GPT model (with or without KV caches
-            already assigned). If caches are not assigned, they are created
-            and assigned temporarily.
-        input_ids: Full input token IDs (prompt + completion),
-            shape ``(batch_size, seq_length)``.
-        logits_to_keep: Number of completion tokens at the end of the
-            sequence for which log-probs are needed.
-        cache_name: KV cache policy name (e.g. "h2o-torch-quantized8",
-            "lastrec-default", "dense-default").
+        gpt_model: KeysAndValues GPT model.
+        input_ids: Full sequence (prompt + completion), shape
+            ``(batch_size, seq_length)``.
+        targets: Target tokens (right-aligned with input_ids), shape
+            ``(batch_size, num_completion_tokens)``.
+        cache_name: KV cache policy name.
         cache_length: Number of slots in the KV cache.
-        chunk_size: Size of each processing chunk after the prefill.
-        cache_kwargs: Additional arguments for KV cache construction.
-        temperature: Temperature for log-prob computation. Values > 1 make
-            the distribution more uniform. Default 1.0 (no scaling).
-        compute_entropy: If True, also compute Shannon entropy at each
-            completion position.
+        chunk_size: Chunk size for post-prefill processing.
+        cache_kwargs: Extra args for KV cache construction.
+        temperature: Scales logits before softmax.
+        compute_entropy: Whether to also return per-token entropy.
 
     Returns:
-        Tuple of (log_probs, entropies):
-            - log_probs: shape ``(batch_size, logits_to_keep)``
-            - entropies: shape ``(batch_size, logits_to_keep)`` or None
-
-    Example::
-
-        from keys_values.logprobs import chunked_per_token_logps
-        from keys_values.model import GPT
-
-        model = GPT(config)
-        model.load_state_dict(...)
-
-        # input_ids is (batch, prompt_len + completion_len)
-        logps, ent = chunked_per_token_logps(
-            gpt_model=model,
-            input_ids=input_ids,
-            logits_to_keep=completion_len,
-            cache_name="h2o-torch-quantized8",
-            cache_length=16384,
-            chunk_size=1024,
-            compute_entropy=True,
-        )
+        Tuple of (log_probs, entropies).
     """
-    batch_size, seq_length = input_ids.shape
-    device, config = input_ids.device, gpt_model.config
+    batch_size = input_ids.shape[0]
+    config = gpt_model.config
     dtype = next(gpt_model.parameters()).dtype
-    completion_start = seq_length - logits_to_keep
 
-    caches_created = _ensure_kv_caches(
-        gpt_model, cache_name, batch_size, cache_length, dtype, cache_kwargs or {}
+    head = LogProbsHeadModel(
+        config, temperature=temperature, compute_entropy=compute_entropy
     )
-    gpt_model.reset()
 
-    chunk_sizes = create_chunk_sizes(
+    caches_created = False
+    if gpt_model.get_kv_caches()[0] is None:
+        gpt_model.assign_kv_caches(
+            KVCacheFactory.create(
+                gpt_model=gpt_model,
+                name=cache_name,
+                max_batch_size=batch_size,
+                cache_length=cache_length,
+                dtype=dtype,
+                cache_kwargs=cache_kwargs or {},
+            )
+        )
+        caches_created = True
+
+    inference_model = LongContextInferenceModel(
         gpt_model=gpt_model,
-        seq_length=seq_length,
+        head_model=head,
         chunk_size=chunk_size,
-        randomize_chunk_sizes=False,
-    )
-    chunks_per_cell = _partition_into_cells(chunk_sizes, cache_length, config)
-    cells = get_chunks_for_cells(chunks_per_cell, chunk_sizes)
-
-    log_probs = torch.zeros(batch_size, logits_to_keep, device=device, dtype=dtype)
-    entropies = (
-        torch.zeros(batch_size, logits_to_keep, device=device, dtype=dtype)
-        if compute_entropy
-        else None
     )
 
-    blocks = [
-        DefaultCellBlocks(model=gpt_model, first_layer_idx=i, num_layers=1)
-        for i in range(config.n_layer)
-    ]
-    wte, scale = gpt_model.transformer.wte, config.n_embd**0.5
+    # Run the forward pass 
+    inference_model(input_ids=input_ids, targets=targets)
 
-    with torch.no_grad():
-        for cell in cells:
-            start, end = cell.input_range
+    logps, entropies = head.get_results()
 
-            embeddings = wte(input_ids[:, start:end])
-            if config.scale_embeddings:
-                embeddings *= scale
-
-            for block in blocks:
-                embeddings = torch.cat(
-                    [
-                        block.forward(
-                            x=embeddings[:, rs:re, :],
-                            idx=input_ids[:, (start + rs) : (start + re)],
-                        )
-                        for rs, re in cell.chunk_ranges
-                    ],
-                    dim=1,
-                )
-
-            for rs, re in cell.chunk_ranges:
-                abs_s, abs_e = start + rs, start + re
-                p_lo = max(abs_s, completion_start - 1)
-                p_hi = min(abs_e, seq_length - 1)
-                if p_lo >= p_hi:
-                    continue
-
-                chunk_logits = gpt_model.lm_head(
-                    embeddings[:, (p_lo - start) : (p_hi - start), :]
-                )
-                if temperature != 1.0:
-                    chunk_logits /= temperature
-
-                targets = input_ids[:, (p_lo + 1) : (p_hi + 1)]
-                out_slice = slice(
-                    p_lo + 1 - completion_start, p_hi + 1 - completion_start
-                )
-                log_probs[:, out_slice] = _selective_log_softmax(chunk_logits, targets)
-
-                if entropies is not None:
-                    entropies[:, out_slice] = _entropy(chunk_logits)
-
-            del embeddings
-
-    write_back_cache_buffers(gpt_model)
     if caches_created:
+        from keys_values.kvcache.factory import deallocate_kv_cache_buffers_of_model
+
         deallocate_kv_cache_buffers_of_model(gpt_model)
         gpt_model.assign_kv_caches([None] * config.n_layer)
 
-    return log_probs, entropies
-
-
-def _ensure_kv_caches(gpt_model, name, batch_size, length, dtype, kwargs) -> bool:
-    """Assign KV caches if not already present. Returns True if we created them."""
-    if (existing := gpt_model.get_kv_caches())[0] is not None:
-        return False
-    gpt_model.assign_kv_caches(
-        KVCacheFactory.create(
-            gpt_model=gpt_model,
-            name=name,
-            max_batch_size=batch_size,
-            cache_length=length,
-            dtype=dtype,
-            cache_kwargs=kwargs,
-        )
-    )
-    return True
-
-
-def _partition_into_cells(chunk_sizes, cache_length, config):
-    """Partition chunks into cells whose total length ≈ cache_length."""
-    max_cell_len = int(
-        2 * config.n_query_groups * config.head_size / config.n_embd * cache_length
-    )
-    cells, cur_len, cur_n = [], 0, 0
-    for cs in chunk_sizes:
-        if cur_n and cur_len + cs > max_cell_len:
-            cells.append(cur_n)
-            cur_len, cur_n = cs, 1
-        else:
-            cur_len += cs
-            cur_n += 1
-    if cur_n:
-        cells.append(cur_n)
-    return cells
-
-
-def _selective_log_softmax(logits: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
-    """Log-softmax + gather — mirrors TRL's implementation."""
-    if logits.dtype in (torch.float32, torch.float64):
-        selected = torch.gather(logits, -1, index.unsqueeze(-1)).squeeze(-1)
-        return selected - torch.logsumexp(logits, dim=-1)
-    return torch.gather(F.log_softmax(logits, dim=-1), -1, index.unsqueeze(-1)).squeeze(
-        -1
-    )
-
-
-def _entropy(logits: torch.Tensor) -> torch.Tensor:
-    """Shannon entropy in nats from logits, shape (..., vocab) → (...)."""
-    p = F.log_softmax(logits, dim=-1)
-    return -(p.exp() * p).sum(-1)
+    return logps, entropies

--- a/keys_values/logprobs.py
+++ b/keys_values/logprobs.py
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Memory-efficient per-token log-probability computation using KV cache.
+
+This module provides :func:`chunked_per_token_logps`, which computes
+per-token log-probabilities using KeysAndValues' chunked forward pass
+with a KV cache policy. Instead of materializing the full
+``(batch, seq_length, vocab_size)`` logits tensor, it processes the
+sequence in chunks and extracts log-probs incrementally.
+
+Memory usage is bounded by ``O(batch * chunk_size * vocab_size)``
+regardless of total sequence length.
+
+For TRL integration, see :class:`keys_values.finetune.grpo.GRPOLongContextTrainer`.
+"""
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from keys_values.kvcache.factory import (
+    KVCacheFactory,
+    deallocate_kv_cache_buffers_of_model,
+)
+from keys_values.kvcache.stack_layers import DefaultCellBlocks
+from keys_values.long_context import (
+    create_chunk_sizes,
+    get_chunks_for_cells,
+    write_back_cache_buffers,
+)
+from keys_values.model import GPT
+
+
+def chunked_per_token_logps(
+    gpt_model: GPT,
+    input_ids: torch.Tensor,
+    logits_to_keep: int,
+    cache_name: str = "h2o-torch-quantized8",
+    cache_length: int = 16384,
+    chunk_size: int = 1024,
+    cache_kwargs: Optional[dict] = None,
+    temperature: float = 1.0,
+    compute_entropy: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Compute per-token log-probs using chunked KV-cache forward pass.
+
+    This is the KeysAndValues alternative to TRL's full-sequence forward.
+    It processes ``input_ids`` chunk by chunk through the model with a KV
+    cache active, only materializing logits for one chunk at a time. For
+    positions corresponding to completion tokens (the last ``logits_to_keep``
+    positions), it extracts log-probs on the fly.
+
+    Memory usage is bounded by ``O(batch * chunk_size * vocab_size)`` for
+    the logits tensor, regardless of total sequence length.
+
+    Args:
+        gpt_model: A KeysAndValues GPT model (with or without KV caches
+            already assigned). If caches are not assigned, they are created
+            and assigned temporarily.
+        input_ids: Full input token IDs (prompt + completion),
+            shape ``(batch_size, seq_length)``.
+        logits_to_keep: Number of completion tokens at the end of the
+            sequence for which log-probs are needed.
+        cache_name: KV cache policy name (e.g. "h2o-torch-quantized8",
+            "lastrec-default", "dense-default").
+        cache_length: Number of slots in the KV cache.
+        chunk_size: Size of each processing chunk after the prefill.
+        cache_kwargs: Additional arguments for KV cache construction.
+        temperature: Temperature for log-prob computation. Values > 1 make
+            the distribution more uniform. Default 1.0 (no scaling).
+        compute_entropy: If True, also compute Shannon entropy at each
+            completion position.
+
+    Returns:
+        Tuple of (log_probs, entropies):
+            - log_probs: shape ``(batch_size, logits_to_keep)``
+            - entropies: shape ``(batch_size, logits_to_keep)`` or None
+
+    Example::
+
+        from keys_values.logprobs import chunked_per_token_logps
+        from keys_values.model import GPT
+
+        model = GPT(config)
+        model.load_state_dict(...)
+
+        # input_ids is (batch, prompt_len + completion_len)
+        logps, ent = chunked_per_token_logps(
+            gpt_model=model,
+            input_ids=input_ids,
+            logits_to_keep=completion_len,
+            cache_name="h2o-torch-quantized8",
+            cache_length=16384,
+            chunk_size=1024,
+            compute_entropy=True,
+        )
+    """
+    batch_size, seq_length = input_ids.shape
+    device, config = input_ids.device, gpt_model.config
+    dtype = next(gpt_model.parameters()).dtype
+    completion_start = seq_length - logits_to_keep
+
+    caches_created = _ensure_kv_caches(
+        gpt_model, cache_name, batch_size, cache_length, dtype, cache_kwargs or {}
+    )
+    gpt_model.reset()
+
+    chunk_sizes = create_chunk_sizes(
+        gpt_model=gpt_model,
+        seq_length=seq_length,
+        chunk_size=chunk_size,
+        randomize_chunk_sizes=False,
+    )
+    chunks_per_cell = _partition_into_cells(chunk_sizes, cache_length, config)
+    cells = get_chunks_for_cells(chunks_per_cell, chunk_sizes)
+
+    log_probs = torch.zeros(batch_size, logits_to_keep, device=device, dtype=dtype)
+    entropies = (
+        torch.zeros(batch_size, logits_to_keep, device=device, dtype=dtype)
+        if compute_entropy
+        else None
+    )
+
+    blocks = [
+        DefaultCellBlocks(model=gpt_model, first_layer_idx=i, num_layers=1)
+        for i in range(config.n_layer)
+    ]
+    wte, scale = gpt_model.transformer.wte, config.n_embd**0.5
+
+    with torch.no_grad():
+        for cell in cells:
+            start, end = cell.input_range
+
+            embeddings = wte(input_ids[:, start:end])
+            if config.scale_embeddings:
+                embeddings *= scale
+
+            for block in blocks:
+                embeddings = torch.cat(
+                    [
+                        block.forward(
+                            x=embeddings[:, rs:re, :],
+                            idx=input_ids[:, (start + rs) : (start + re)],
+                        )
+                        for rs, re in cell.chunk_ranges
+                    ],
+                    dim=1,
+                )
+
+            for rs, re in cell.chunk_ranges:
+                abs_s, abs_e = start + rs, start + re
+                p_lo = max(abs_s, completion_start - 1)
+                p_hi = min(abs_e, seq_length - 1)
+                if p_lo >= p_hi:
+                    continue
+
+                chunk_logits = gpt_model.lm_head(
+                    embeddings[:, (p_lo - start) : (p_hi - start), :]
+                )
+                if temperature != 1.0:
+                    chunk_logits /= temperature
+
+                targets = input_ids[:, (p_lo + 1) : (p_hi + 1)]
+                out_slice = slice(
+                    p_lo + 1 - completion_start, p_hi + 1 - completion_start
+                )
+                log_probs[:, out_slice] = _selective_log_softmax(chunk_logits, targets)
+
+                if entropies is not None:
+                    entropies[:, out_slice] = _entropy(chunk_logits)
+
+            del embeddings
+
+    write_back_cache_buffers(gpt_model)
+    if caches_created:
+        deallocate_kv_cache_buffers_of_model(gpt_model)
+        gpt_model.assign_kv_caches([None] * config.n_layer)
+
+    return log_probs, entropies
+
+
+def _ensure_kv_caches(gpt_model, name, batch_size, length, dtype, kwargs) -> bool:
+    """Assign KV caches if not already present. Returns True if we created them."""
+    if (existing := gpt_model.get_kv_caches())[0] is not None:
+        return False
+    gpt_model.assign_kv_caches(
+        KVCacheFactory.create(
+            gpt_model=gpt_model,
+            name=name,
+            max_batch_size=batch_size,
+            cache_length=length,
+            dtype=dtype,
+            cache_kwargs=kwargs,
+        )
+    )
+    return True
+
+
+def _partition_into_cells(chunk_sizes, cache_length, config):
+    """Partition chunks into cells whose total length ≈ cache_length."""
+    max_cell_len = int(
+        2 * config.n_query_groups * config.head_size / config.n_embd * cache_length
+    )
+    cells, cur_len, cur_n = [], 0, 0
+    for cs in chunk_sizes:
+        if cur_n and cur_len + cs > max_cell_len:
+            cells.append(cur_n)
+            cur_len, cur_n = cs, 1
+        else:
+            cur_len += cs
+            cur_n += 1
+    if cur_n:
+        cells.append(cur_n)
+    return cells
+
+
+def _selective_log_softmax(logits: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+    """Log-softmax + gather — mirrors TRL's implementation."""
+    if logits.dtype in (torch.float32, torch.float64):
+        selected = torch.gather(logits, -1, index.unsqueeze(-1)).squeeze(-1)
+        return selected - torch.logsumexp(logits, dim=-1)
+    return torch.gather(F.log_softmax(logits, dim=-1), -1, index.unsqueeze(-1)).squeeze(
+        -1
+    )
+
+
+def _entropy(logits: torch.Tensor) -> torch.Tensor:
+    """Shannon entropy in nats from logits, shape (..., vocab) → (...)."""
+    p = F.log_softmax(logits, dim=-1)
+    return -(p.exp() * p).sum(-1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cuda = ["flashinfer-python"]
+trl = ["trl>=1.0.0"]
 
 [tool.setuptools.packages.find]
 include = [

--- a/test/test_logprobs.py
+++ b/test/test_logprobs.py
@@ -14,21 +14,19 @@
 """
 Tests for :mod:`keys_values.logprobs`.
 
-Verifies that ``chunked_per_token_logps`` integrates correctly with the
-KeysAndValues model infrastructure (GPT + KV caches + MHA) and produces
-correct per-token log-probabilities.
+Verifies that ``compute_logprobs`` produces correct per-token
+log-probabilities using the LongContextInferenceModel infrastructure.
 """
 import pytest
 import torch
 
 from keys_values.config import Config
-from keys_values.logprobs import chunked_per_token_logps
-from keys_values.model import GPT
+from keys_values.logprobs import compute_logprobs
 
 
-def _small_config(**overrides) -> Config:
+def _small_config() -> Config:
     """Minimal GPT config for fast CPU tests."""
-    defaults = dict(
+    return Config(
         n_layer=2,
         n_head=4,
         n_embd=64,
@@ -38,40 +36,20 @@ def _small_config(**overrides) -> Config:
         padded_vocab_size=256,
         intermediate_size=128,
     )
-    defaults.update(overrides)
-    return Config(**defaults)
 
 
-def _reference_logps(
-    gpt_model: GPT,
-    input_ids: torch.Tensor,
-    logits_to_keep: int,
-    temperature: float = 1.0,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Ground truth: use chunked_per_token_logps with dense cache == seq_length.
+def _make_model():
+    from keys_values.model import GPT
 
-    With a dense cache large enough for the full sequence, there's no
-    eviction — this gives exact log-probs as if we did a single forward pass.
-    """
-    return chunked_per_token_logps(
-        gpt_model=gpt_model,
-        input_ids=input_ids,
-        logits_to_keep=logits_to_keep,
-        cache_name="dense-default",
-        cache_length=input_ids.shape[1],
-        chunk_size=input_ids.shape[1],  # single chunk = full forward
-        temperature=temperature,
-        compute_entropy=True,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+    config = _small_config()
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+    return model, config
 
 
 @pytest.mark.parametrize(
-    "seq_length, logits_to_keep, chunk_size",
+    "seq_length, completion_length, chunk_size",
     [
         (32, 8, 16),
         (64, 16, 8),
@@ -79,30 +57,31 @@ def _reference_logps(
         (100, 30, 20),
     ],
 )
-def test_chunked_matches_dense_full(seq_length, logits_to_keep, chunk_size):
-    """Chunked processing with dense cache should match single-chunk reference.
-
-    Both use a dense cache (no eviction), so the only difference is how many
-    chunks the sequence is split into. Results must be identical.
-    """
+def test_chunked_matches_single_chunk(seq_length, completion_length, chunk_size):
+    """Chunked computation should match single-chunk (full forward) result."""
     torch.manual_seed(42)
-    config = _small_config()
+    model, config = _make_model()
     batch_size = 2
 
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
-
     input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_length))
+    targets = input_ids[:, -completion_length:]
 
-    # Reference: dense cache, single chunk (full forward)
-    ref_logps, ref_ent = _reference_logps(model, input_ids, logits_to_keep)
-
-    # Under test: dense cache but split into multiple chunks
-    test_logps, test_ent = chunked_per_token_logps(
+    # Reference: dense cache, single large chunk (effectively full forward)
+    ref_logps, ref_ent = compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=logits_to_keep,
+        targets=targets,
+        cache_name="dense-default",
+        cache_length=seq_length,
+        chunk_size=seq_length,
+        compute_entropy=True,
+    )
+
+    # Under test: same dense cache but split into multiple chunks
+    test_logps, test_ent = compute_logprobs(
+        gpt_model=model,
+        input_ids=input_ids,
+        targets=targets,
         cache_name="dense-default",
         cache_length=seq_length,
         chunk_size=chunk_size,
@@ -115,26 +94,28 @@ def test_chunked_matches_dense_full(seq_length, logits_to_keep, chunk_size):
 
 @pytest.mark.parametrize("temperature", [0.5, 1.0, 2.0])
 def test_temperature_scaling(temperature):
-    """Temperature should consistently scale logits before softmax."""
+    """Temperature should consistently scale logits."""
     torch.manual_seed(123)
-    config = _small_config()
-    seq_length, logits_to_keep = 40, 10
+    model, config = _make_model()
 
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
+    input_ids = torch.randint(0, config.vocab_size, (1, 40))
+    targets = input_ids[:, -10:]
 
-    input_ids = torch.randint(0, config.vocab_size, (1, seq_length))
-
-    ref_logps, _ = _reference_logps(
-        model, input_ids, logits_to_keep, temperature
-    )
-    test_logps, _ = chunked_per_token_logps(
+    ref_logps, _ = compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=logits_to_keep,
+        targets=targets,
         cache_name="dense-default",
-        cache_length=seq_length,
+        cache_length=40,
+        chunk_size=40,
+        temperature=temperature,
+    )
+    test_logps, _ = compute_logprobs(
+        gpt_model=model,
+        input_ids=input_ids,
+        targets=targets,
+        cache_name="dense-default",
+        cache_length=40,
         chunk_size=16,
         temperature=temperature,
     )
@@ -145,18 +126,15 @@ def test_temperature_scaling(temperature):
 def test_no_entropy_returns_none():
     """When compute_entropy=False, entropies should be None."""
     torch.manual_seed(7)
-    config = _small_config()
-
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
+    model, config = _make_model()
 
     input_ids = torch.randint(0, config.vocab_size, (1, 32))
+    targets = input_ids[:, -8:]
 
-    _, ent = chunked_per_token_logps(
+    _, ent = compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=8,
+        targets=targets,
         cache_name="dense-default",
         cache_length=32,
         chunk_size=16,
@@ -166,21 +144,19 @@ def test_no_entropy_returns_none():
 
 
 def test_caches_cleaned_up():
-    """After chunked_per_token_logps, KV caches should be removed."""
+    """After compute_logprobs, KV caches should be removed."""
     torch.manual_seed(99)
-    config = _small_config()
-
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
+    model, config = _make_model()
 
     assert model.get_kv_caches()[0] is None
 
     input_ids = torch.randint(0, config.vocab_size, (1, 32))
-    chunked_per_token_logps(
+    targets = input_ids[:, -8:]
+
+    compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=8,
+        targets=targets,
         cache_name="dense-default",
         cache_length=32,
         chunk_size=16,
@@ -189,47 +165,41 @@ def test_caches_cleaned_up():
     assert model.get_kv_caches()[0] is None
 
 
-def test_logps_shape():
-    """Output shapes should match (batch_size, logits_to_keep)."""
+def test_output_shapes():
+    """Output shapes should match (batch_size, completion_length)."""
     torch.manual_seed(55)
-    config = _small_config()
-    batch_size, seq_length, logits_to_keep = 3, 50, 15
-
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
+    model, config = _make_model()
+    batch_size, seq_length, completion_length = 3, 50, 15
 
     input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_length))
+    targets = input_ids[:, -completion_length:]
 
-    logps, ent = chunked_per_token_logps(
+    logps, ent = compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=logits_to_keep,
+        targets=targets,
         cache_name="dense-default",
         cache_length=seq_length,
         chunk_size=20,
         compute_entropy=True,
     )
 
-    assert logps.shape == (batch_size, logits_to_keep)
-    assert ent.shape == (batch_size, logits_to_keep)
+    assert logps.shape == (batch_size, completion_length)
+    assert ent.shape == (batch_size, completion_length)
 
 
 def test_logps_are_negative():
     """Log-probabilities should always be <= 0."""
     torch.manual_seed(77)
-    config = _small_config()
-
-    with torch.device("cpu"):
-        model = GPT(config)
-    model.eval()
+    model, config = _make_model()
 
     input_ids = torch.randint(0, config.vocab_size, (2, 40))
+    targets = input_ids[:, -10:]
 
-    logps, _ = chunked_per_token_logps(
+    logps, _ = compute_logprobs(
         gpt_model=model,
         input_ids=input_ids,
-        logits_to_keep=10,
+        targets=targets,
         cache_name="dense-default",
         cache_length=40,
         chunk_size=16,

--- a/test/test_logprobs.py
+++ b/test/test_logprobs.py
@@ -17,6 +17,7 @@ Tests for :mod:`keys_values.logprobs`.
 Verifies that ``compute_logprobs`` produces correct per-token
 log-probabilities using the LongContextInferenceModel infrastructure.
 """
+
 import pytest
 import torch
 

--- a/test/test_logprobs.py
+++ b/test/test_logprobs.py
@@ -1,0 +1,238 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for :mod:`keys_values.logprobs`.
+
+Verifies that ``chunked_per_token_logps`` integrates correctly with the
+KeysAndValues model infrastructure (GPT + KV caches + MHA) and produces
+correct per-token log-probabilities.
+"""
+import pytest
+import torch
+
+from keys_values.config import Config
+from keys_values.logprobs import chunked_per_token_logps
+from keys_values.model import GPT
+
+
+def _small_config(**overrides) -> Config:
+    """Minimal GPT config for fast CPU tests."""
+    defaults = dict(
+        n_layer=2,
+        n_head=4,
+        n_embd=64,
+        n_query_groups=2,
+        block_size=512,
+        vocab_size=256,
+        padded_vocab_size=256,
+        intermediate_size=128,
+    )
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+def _reference_logps(
+    gpt_model: GPT,
+    input_ids: torch.Tensor,
+    logits_to_keep: int,
+    temperature: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Ground truth: use chunked_per_token_logps with dense cache == seq_length.
+
+    With a dense cache large enough for the full sequence, there's no
+    eviction — this gives exact log-probs as if we did a single forward pass.
+    """
+    return chunked_per_token_logps(
+        gpt_model=gpt_model,
+        input_ids=input_ids,
+        logits_to_keep=logits_to_keep,
+        cache_name="dense-default",
+        cache_length=input_ids.shape[1],
+        chunk_size=input_ids.shape[1],  # single chunk = full forward
+        temperature=temperature,
+        compute_entropy=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "seq_length, logits_to_keep, chunk_size",
+    [
+        (32, 8, 16),
+        (64, 16, 8),
+        (48, 12, 32),
+        (100, 30, 20),
+    ],
+)
+def test_chunked_matches_dense_full(seq_length, logits_to_keep, chunk_size):
+    """Chunked processing with dense cache should match single-chunk reference.
+
+    Both use a dense cache (no eviction), so the only difference is how many
+    chunks the sequence is split into. Results must be identical.
+    """
+    torch.manual_seed(42)
+    config = _small_config()
+    batch_size = 2
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_length))
+
+    # Reference: dense cache, single chunk (full forward)
+    ref_logps, ref_ent = _reference_logps(model, input_ids, logits_to_keep)
+
+    # Under test: dense cache but split into multiple chunks
+    test_logps, test_ent = chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=logits_to_keep,
+        cache_name="dense-default",
+        cache_length=seq_length,
+        chunk_size=chunk_size,
+        compute_entropy=True,
+    )
+
+    torch.testing.assert_close(test_logps, ref_logps, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(test_ent, ref_ent, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("temperature", [0.5, 1.0, 2.0])
+def test_temperature_scaling(temperature):
+    """Temperature should consistently scale logits before softmax."""
+    torch.manual_seed(123)
+    config = _small_config()
+    seq_length, logits_to_keep = 40, 10
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (1, seq_length))
+
+    ref_logps, _ = _reference_logps(
+        model, input_ids, logits_to_keep, temperature
+    )
+    test_logps, _ = chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=logits_to_keep,
+        cache_name="dense-default",
+        cache_length=seq_length,
+        chunk_size=16,
+        temperature=temperature,
+    )
+
+    torch.testing.assert_close(test_logps, ref_logps, atol=1e-4, rtol=1e-4)
+
+
+def test_no_entropy_returns_none():
+    """When compute_entropy=False, entropies should be None."""
+    torch.manual_seed(7)
+    config = _small_config()
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (1, 32))
+
+    _, ent = chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=8,
+        cache_name="dense-default",
+        cache_length=32,
+        chunk_size=16,
+        compute_entropy=False,
+    )
+    assert ent is None
+
+
+def test_caches_cleaned_up():
+    """After chunked_per_token_logps, KV caches should be removed."""
+    torch.manual_seed(99)
+    config = _small_config()
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    assert model.get_kv_caches()[0] is None
+
+    input_ids = torch.randint(0, config.vocab_size, (1, 32))
+    chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=8,
+        cache_name="dense-default",
+        cache_length=32,
+        chunk_size=16,
+    )
+
+    assert model.get_kv_caches()[0] is None
+
+
+def test_logps_shape():
+    """Output shapes should match (batch_size, logits_to_keep)."""
+    torch.manual_seed(55)
+    config = _small_config()
+    batch_size, seq_length, logits_to_keep = 3, 50, 15
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_length))
+
+    logps, ent = chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=logits_to_keep,
+        cache_name="dense-default",
+        cache_length=seq_length,
+        chunk_size=20,
+        compute_entropy=True,
+    )
+
+    assert logps.shape == (batch_size, logits_to_keep)
+    assert ent.shape == (batch_size, logits_to_keep)
+
+
+def test_logps_are_negative():
+    """Log-probabilities should always be <= 0."""
+    torch.manual_seed(77)
+    config = _small_config()
+
+    with torch.device("cpu"):
+        model = GPT(config)
+    model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 40))
+
+    logps, _ = chunked_per_token_logps(
+        gpt_model=model,
+        input_ids=input_ids,
+        logits_to_keep=10,
+        cache_name="dense-default",
+        cache_length=40,
+        chunk_size=16,
+    )
+
+    assert (logps <= 0).all(), f"Found positive log-probs: {logps.max()}"


### PR DESCRIPTION
## TRL Integration: Chunked Log-Prob Computation for GRPO

### Motivation

This is the first step toward integrating KeysAndValues with HuggingFace TRL
for RL fine-tuning (GRPO/DPO) on long contexts. TRL's GRPOTrainer computes
per-token log-probabilities via a full forward pass, which OOMs on long
sequences. KeysAndValues can compute the same log-probs chunk by chunk through
a KV cache, with bounded GPU memory regardless of sequence length.

### What's included

- `keys_values/logprobs.py`: `chunked_per_token_logps()` — computes per-token
  log-probs using the existing chunked KV-cache forward infrastructure. Memory
  bounded by O(batch * chunk_size * vocab_size).
- `keys_values/finetune/grpo.py`: `GRPOLongContextTrainer` — subclass of TRL's
  `GRPOTrainer` that overrides `_get_per_token_logps_and_entropies` to route
  long sequences through the chunked path. Short sequences fall through to
  TRL's default (zero overhead).
- `test/test_logprobs.py`: 11 tests verifying correctness (chunked matches
  dense full-forward, temperature scaling, shapes, cleanup).
- `pyproject.toml`: Added `trl` as an optional dependency (`pip install keys_values[trl]`).

### Design decisions

- The log-prob utility (`logprobs.py`) has no TRL dependency — it's a general
  purpose function usable anywhere you need log-probs from long sequences.
- The trainer subclass lives in `finetune/` alongside the existing fine-tuning
  scripts.
- Threshold-based routing: only sequences exceeding `kv_cache_length` use the
  chunked path.

### Next steps

Full end-to-end pipeline (generation + model adapter bridging keys_values GPT
with HuggingFace's PreTrainedModel interface) will follow in a subsequent PR.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
