### PR TITLE
Improve SmartInitialLastRecentlyInsertedKVCache by defining protected…

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,12 +561,19 @@ currently supported:
   cache is full, new information overwrites slots which have not been
   overwritten for the longest time.
 * `smart-lastrec`: [SmartInitialLastRecentlyInsertedKVCache](./keys_values/kvcache/smart_lastrec.py#130).
-  Variant of `lastrec`, where the initial (grace) part of the prompt, which is
+  Variant of `lastrec`, where the protected range of the prompt, which is
   kept in the cache, is defined by a regular expression determining the end of
   it. If you write prompts with important information up front (e.g., a
   "system prompt"), use a string which marks the end of this. This policy needs
   some configuration in `kv_cache.cache_kwargs`, defaults for which can be
-  provided with the dataset (see below).
+  provided with the dataset (see below).<br>
+  If `kv_cache.range_is_prefix` is set to `False`, the protected range need not
+  be a prefix. In fact, any left-padding tokens are excluded from the range,
+  so it starts with the first non-padding token. The idea is that padding
+  tokens should not be attended to.<br>
+  TODO: The default for this parameter is `True`, because some initial
+  experiments were not conclusive. This needs to be revisited. Why would
+  left-padding tokens be useful in the cache?
 * `h2o`: [H2OKVCache](./keys_values/kvcache/h2o.py#L28). Implements an improved
   variant of the heavy hitter oracle (H2O) strategy (for citation, see
   docstring). H2O scores each `(b, h, j)` by the sum of attention weights

--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -52,6 +52,7 @@ _CACHE_KWARGS_NAMES = (
     "grace_period",
     "init_grace_tokens",
     "normalize_scores",
+    "range_is_prefix",
 )
 
 
@@ -88,6 +89,13 @@ class KVCacheArgs:
         normalize_scores: Only for H2O and q-H2O cache policies. If `True`,
             score values are normalized by the number of token positions an
             entry is in the cache already.
+        range_is_prefix: Only for `smart-lastrec` cache policy. If `False`, the
+            protected range per batch position need not be a prefix. In fact,
+            all left-padding tokens are excluded from the protected range.
+            TODO: Intuitively, `range_is_prefix=False` should work better,
+            because left-padding tokens should not be attended to. Initial
+            experiments did not show an advantage though. Needs to be revisited
+            (maybe some of the left-pad tokens are useful, as attention sinks?).
     """
 
     name: str
@@ -100,6 +108,7 @@ class KVCacheArgs:
     init_grace_tokens: int = 0
     cpu_offload: bool = False
     normalize_scores: bool = False
+    range_is_prefix: bool = True
     # Legacy (these are global args now)
     verbose: Optional[str] = None
     attention_forward_temp_size_gb: Optional[float] = None

--- a/keys_values/kvcache/factory.py
+++ b/keys_values/kvcache/factory.py
@@ -544,6 +544,7 @@ SMART_LASTREC_REMKEYS = (
     "include_end_string",
     "max_initial_fraction",
     "tokenizer",
+    "range_is_prefix",
 )
 
 ATTN_WEIGHTS_REMKEYS = (

--- a/keys_values/kvcache/gradient/inference_replay.py
+++ b/keys_values/kvcache/gradient/inference_replay.py
@@ -437,12 +437,16 @@ class InferenceSmartInitialLastRecentlyInsertedReplayCache(
         value: torch.Tensor,
         token_idx: torch.Tensor,
     ) -> KeysAndValues:
-        if self.init_length != self.replay_log.init_length:
-            raise AssertionError(
-                f"init_length:            {self.init_length}\n"
-                f"replay_log.init_length: {self.replay_log.init_length}\n"
-                "Must be the same!"
-            )
+        for v1, v2, name in [
+            (self.protected_start, self.replay_log.protected_start, "protected_start"),
+            (self.protected_end, self.replay_log.protected_end, "protected_end"),
+        ]:
+            if v1 != v2:
+                raise AssertionError(
+                    f"{name}:            {v1}\n"
+                    f"replay_log.{name}: {v2}\n"
+                    "Must be the same!"
+                )
         return super()._forward_internal(key, value, token_idx)
 
 

--- a/keys_values/kvcache/h2o.py
+++ b/keys_values/kvcache/h2o.py
@@ -348,8 +348,8 @@ class VLengthH2OKVCache(H2OKVCache, VLengthInstantScoreMixin):
     attention weights. The instantaneous score is:
 
     ..math::
-        S(j) = n_Q * m_j |v_j| / Z,  Z = \sum_j m_j |v_j|,
-         m_j = \sum_i m_{i,j}
+        S(j) = n_Q * m_j |v_j| / Z,  Z = sum_j m_j |v_j|,
+         m_j = sum_i m_{i,j}
 
     Namely, `m_j` is `attn_weights` summed over the query axis, `|v_j|` the
     norm of the v vector, n_Q the length of the query axis (`query_length`
@@ -358,7 +358,6 @@ class VLengthH2OKVCache(H2OKVCache, VLengthInstantScoreMixin):
     Different to H2O, this score takes the length of v vectors into account as
     well, which in the end determine the attention outputs alongside the
     attention weights.
-
     """
 
     def __init__(

--- a/keys_values/kvcache/smart_lastrec.py
+++ b/keys_values/kvcache/smart_lastrec.py
@@ -34,7 +34,7 @@ from keys_values.kvcache.buffers import (
     positions_wrap_around,
 )
 from keys_values.config import Config
-from keys_values.utils import bits_for_torch_dtype, bitsize_of, encode
+from keys_values.utils import bits_for_torch_dtype, bitsize_of, encode, index_to_3d
 
 
 @dataclass(frozen=True)
@@ -81,9 +81,157 @@ def end_initial_regex_from_string(
     return result
 
 
+def update_next_position(
+    cache_length: int,
+    positions: torch.Tensor,
+    protected_start: List[Optional[int]],
+    protected_end: List[Optional[int]],
+    next_position: List[int],
+):
+    assert positions.ndim == 2  # Sanity check
+    for bpos, (pos_for_b, pstart, pend) in enumerate(
+        zip(positions, protected_start, protected_end)
+    ):
+        np = pos_for_b[-1].item() + 1
+        if pstart is None:
+            np = np % cache_length
+        else:
+            wrap_around = pstart > pend
+            if not wrap_around:
+                if np == cache_length:
+                    # If `pstart == 0`, must have `pend < cache_length`
+                    np = 0 if pstart > 0 else pend
+                elif np == pstart:
+                    # If `pend == cache_length`, must have `pstart > 0`
+                    np = pend % cache_length
+            elif np == pstart:
+                np = pend
+        next_position[bpos] = np
+
+
+def positions_outside_protected_range(
+    num: int,
+    current: int,
+    end: int,
+    protected_start: int,
+    protected_end: int,
+    **index_kwargs,
+) -> torch.Tensor:
+    wrap_around = protected_start > protected_end
+    if not wrap_around:
+        assert 0 <= protected_start < protected_end <= end
+        assert 0 <= current < protected_start or protected_end <= current < end
+        assert protected_end - protected_start < end
+    else:
+        assert 0 < protected_end < protected_start < end
+        assert protected_end <= current < protected_start
+    parts = []
+    remainder = num
+    while remainder > 0:
+        diff = protected_start - current
+        if diff > 0:
+            # Left of `protected_start`
+            diff = min(diff, remainder)
+            part = torch.arange(current, current + diff, **index_kwargs)
+            remainder -= diff
+            # Only used again if `remainder > 0`
+            current = protected_end % end
+        elif not wrap_around:
+            # Right of `protected_end` (only different from the other case
+            # if not wrap around)
+            diff = min(end - current, remainder)
+            part = torch.arange(current, current + diff, **index_kwargs)
+            remainder -= diff
+            # Only used again if `remainder > 0`
+            current = 0 if protected_start > 0 else protected_end
+        parts.append(part)
+    return torch.cat(parts, dim=0)
+
+
+def extract_index(
+    num: int,
+    cache_length: int,
+    protected_start: List[Optional[int]],
+    protected_end: List[Optional[int]],
+    next_position: List[int],
+    n_query_groups: int,
+    **index_kwargs,
+) -> List[Tuple[torch.Tensor, int, int]]:
+    # Maximum number of slots which can be written in a single
+    # step, without writing to some slot twice
+    max_one_step = cache_length - max(
+        b - a if a is not None else 0 for a, b in zip(protected_start, protected_end)
+    )
+    if num <= max_one_step:
+        offs_and_nums = ((0, num),)
+    else:
+        # Only happens if `num` is very large
+        assert (
+            num <= 2 * max_one_step
+        ), f"Internal error: num = {num}, max_one_step = {max_one_step}"
+        offs_and_nums = (
+            (0, max_one_step),
+            (max_one_step, num - max_one_step),
+        )
+        next_position = copy.copy(next_position)
+    result = []
+    for off, _num in offs_and_nums:
+        # Determine `positions` for forward
+        # If there is no range yet for a batch position, cache positions
+        # are token positions module `cache_length`
+        position_parts = [
+            (
+                index_to_3d(
+                    positions_outside_protected_range(
+                        num=_num,
+                        current=np,
+                        end=cache_length,
+                        protected_start=pstart,
+                        protected_end=pend,
+                        **index_kwargs,
+                    ),
+                    1,
+                    n_query_groups,
+                )
+                if pstart is not None
+                else positions_wrap_around(
+                    num=_num,
+                    current=np,
+                    start=0,
+                    end=cache_length,
+                    batch_size=1,
+                    n_query_groups=n_query_groups,
+                    return_tensor=True,
+                    **index_kwargs,
+                )
+            )
+            for np, pstart, pend in zip(
+                next_position,
+                protected_start,
+                protected_end,
+            )
+        ]
+        positions = torch.cat(position_parts, dim=0)
+        result.append((positions, off, _num))
+        if len(offs_and_nums) > 1:
+            update_next_position(
+                cache_length=cache_length,
+                positions=positions[:, 0, :],
+                protected_start=protected_start,
+                protected_end=protected_end,
+                next_position=next_position,
+            )
+    return result
+
+
 class SmartInitialLastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
     """
     Replay log for :class:`SmartInitialLastRecentlyInsertedKVCache`.
+
+    `next_position_for_input_pos` maps `input_pos` values to `next_position`
+    lists. Entries are passed with :meth:`update`. We need to store these,
+    because we cannot easily compute `next_position` from `input_pos`: this
+    depends on the chunk for which the protected range was set.
     """
 
     def __init__(
@@ -96,7 +244,9 @@ class SmartInitialLastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
         max_initial_fraction: float,
         include_end_string: bool,
         pad_id: int,
-        init_length: List[int],
+        range_is_prefix: bool,
+        protected_start: List[Optional[int]],
+        protected_end: List[Optional[int]],
     ):
         super().__init__(
             token_chunks,
@@ -110,7 +260,31 @@ class SmartInitialLastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
         self.max_initial_fraction = max_initial_fraction
         self.include_end_string = include_end_string
         self.pad_id = pad_id
-        self.init_length = init_length.copy()
+        self.range_is_prefix = range_is_prefix
+        self.protected_start = None
+        self.protected_end = None
+        # Map of `input_pos` to `next_position`. This is needed because
+        # we cannot easily compute this map. It depends on when each
+        # protected range was fixed (this may happen during a chunk later
+        # than the prefill one).
+        self.next_position_for_input_pos = dict()
+        self.update(
+            protected_start=protected_start,
+            protected_end=protected_end,
+            input_pos=0,
+            next_position=[0] * len(protected_start),
+        )
+
+    def update(
+        self,
+        protected_start: List[Optional[int]],
+        protected_end: List[Optional[int]],
+        input_pos: int,
+        next_position: List[int],
+    ):
+        self.protected_start = protected_start.copy()
+        self.protected_end = protected_end.copy()
+        self.next_position_for_input_pos[input_pos] = next_position.copy()
 
     def extract_index(
         self,
@@ -130,69 +304,65 @@ class SmartInitialLastRecentlyInsertedKVCacheReplayLog(DefaultKVCacheReplayLog):
             )
         if device is None:
             device = torch.get_default_device()
-        max_one_step = self.cache_length - max(self.init_length)
-        if num <= max_one_step:
-            offs_and_nums = ((0, num),)
-        else:
-            # Only happens if `num` is very large
-            # In this case, we create two indexes and concatenate them. This may
-            # not be exactly correct, because of duplicate entries. Very large
-            # chunks should be avoided!
-            offs_and_nums = (
-                (0, max_one_step),
-                (max_one_step, num - max_one_step),
+        next_position = self.next_position_for_input_pos.get(input_pos)
+        if next_position is None:
+            raise IndexError(
+                f"input_pos = {input_pos} not represented (keys are {list(self.next_position_for_input_pos.keys())})"
             )
-        positions = []
-        for off, _num in offs_and_nums:
-            _input_pos = input_pos + off
-            position_parts = []
-            for start in self.init_length:
-                mod = self.cache_length - start
-                current = (_input_pos - self.cache_length) % mod + start
-                position_parts.append(
-                    positions_wrap_around(
-                        num=num,
-                        current=current,
-                        start=start,
-                        end=self.cache_length,
-                        batch_size=1,
-                        n_query_groups=self.n_query_groups,
-                        device=device,
-                        return_tensor=True,
-                        dtype=dtype,
-                    )
-                )
-            positions.append(torch.cat(position_parts, dim=0))
-
-        if len(positions) == 1:
-            return positions[0]
+        indexes = extract_index(
+            num=num,
+            cache_length=self.cache_length,
+            protected_start=self.protected_start,
+            protected_end=self.protected_end,
+            next_position=next_position,
+            n_query_groups=self.n_query_groups,
+            dtype=dtype,
+            device=device,
+        )
+        if len(indexes) == 1:
+            return indexes[0][0]
         else:
-            return torch.cat(positions, dim=-1)
+            return torch.cat([x[0] for x in indexes], dim=-1)
 
 
 class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
     """
-    Advanced variant of :class:`LastRecentlyInsertedKVCache`. Here, the initial
-    "grace" part kept in the cache indefinitely can be of different length for
-    each batch position and depends on the prompt content.
+    Advanced variant of :class:`LastRecentlyInsertedKVCache`. For each batch
+    dimension, there is a protected range of cache positions, KV information
+    for which remains in the cache, namely
+    `range(protected_start[b], protected_end[b])` for each batch position `b`.
 
     A regular expression `end_initial_regex` is passed at construction.
-    The length of initial parts (in tokens) per batch position is kept in
-    `init_length`. It is determined in :meth:`prefill`. Namely,
-    `init_length[b]` is the smallest of:
+    Protected ranges are determined in :meth:`prefill`, and possibly in
+    subsequent :meth:`forward` calls. Namely, `protected_start[b]` is the cache
+    position of the first non-padding token (cache position before protected
+    range is token position modulo cache length). `protected_end[b]` is the
+    smallest of:
 
     * `end` (if `include_end_string == True`) or `start` (if
       `include_end_string == False`) if the first match of `end_initial_regex`
       in the string decoded from the token sequence `token_idx[b, :]` has span
       `(start, end)`.
-    * `int(max_initial_fraction * cache_length)`
-    * Prefill length `key.shape[2]`
+    * `protected_start[b] + int(max_initial_fraction * cache_length)`
+    * Chunk length `key.shape[2]`
 
-    In other words, the initial parts are terminated by a certain string
-    pattern described by `end_initial_regex`, and the pattern is included in the
+    In other words, protected ranges are terminated by a certain string pattern
+    described by `end_initial_regex`, and the pattern is included in the
     initial parts iff `include_end_string == True`. However, both
     `int(max_initial_fraction * cache_length)` and the prefill length limit the
-    initial part lengths.
+    length of the ranges. Also, the protected range must lie within a chunk
+    and also not wrap around (for simplicity).
+
+    The projected range may wrap around. If `protected_start[b] > protected_end[b]`,
+    it is in fact `range(protected_start[b], cache_length)` plus
+    `range(0, protected_end[b])`.
+
+    If `range_is_prefix == True`, protected ranges are prefixes, so
+    `protected_start[b] = 0` and they are always determined from the prefill
+    chunk. In this case, protected ranges may contain left-padding tokens.
+
+    TODO: This option is switched on by default, since we ran experiments with
+    `range_is_prefix == False` and did not see improvements. To be revisited!
 
     ATTENTION: The regular expression `end_initial_regex` is matched against
     a string coming out of `tokenizer.decode(..., skip_special_tokens=True)`. It
@@ -213,6 +383,7 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
         max_initial_fraction: float,
         include_end_string: bool = True,
         pad_id: int = 0,
+        range_is_prefix: bool = True,
         **base_kwargs,
     ):
         super().__init__(config, buffers, block_idx, **base_kwargs)
@@ -230,10 +401,12 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
             )
         self.max_initial_fraction = max_initial_fraction
         self.include_end_string = include_end_string
-        # Lengths of initial parts (per batch dimension)
-        self.init_length = None
+        self.range_is_prefix = range_is_prefix
+        # Protected ranges
+        self.protected_start = None
+        self.protected_end = None
         # Note: We could generate `token_pos` on the fly from `input_pos`,
-        # `next_position` and `init_length`, but it is simpler just to maintain
+        # `next_position` and `protected_*`, but it is simpler just to maintain
         # it.
         device = self._default_device_for_new_params()
         self.register_buffer(
@@ -264,6 +437,8 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
         end_initial_regex: Union[str, re.Pattern],
         max_initial_fraction: float,
         include_end_string: bool = True,
+        pad_id: int = 0,
+        range_is_prefix: bool = True,
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
         **base_kwargs,
@@ -285,6 +460,9 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
             max_initial_fraction: Fraction of cache length initial parts can
                 occupy at most
             include_end_string: Include end of init sequence in initial part?
+            pad_id: Index of padding token (defaults to 0)
+            range_is_prefix: If `True`, protected ranges are prefixes and may
+                contain left-padding tokens (defaults to `True`)
             device: Device for buffers. If not given, it is set with the
                 first :meth:`forward` call, based on the input arguments.
             dtype: Data type for buffers. If not given, it is set with the
@@ -309,6 +487,8 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
             end_initial_regex,
             max_initial_fraction,
             include_end_string=include_end_string,
+            pad_id=pad_id,
+            range_is_prefix=range_is_prefix,
             **base_kwargs,
         )
 
@@ -325,124 +505,140 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
         value: torch.Tensor,
         token_idx: torch.Tensor,
     ) -> KeysAndValues:
-        total_num = key.shape[2]
-        max_one_step = self.cache_length - max(self.init_length)
-        if total_num <= max_one_step:
-            offs_and_nums = ((0, total_num),)
-        else:
-            # Only happens if `total_num` is very large
-            offs_and_nums = (
-                (0, max_one_step),
-                (max_one_step, total_num - max_one_step),
-            )
-        tp_kwargs = dict(device=self.device, dtype=torch.int)
-        k_and_v = None
-        for off, num in offs_and_nums:
-            # Determine `positions` for forward
-            position_parts = [
-                positions_wrap_around(
-                    num=num,
-                    current=np,
-                    start=start,
-                    end=self.cache_length,
-                    batch_size=1,
-                    n_query_groups=self.n_query_groups,
-                    device=self.device,
-                    return_tensor=True,
+        use_range = self._update_protected_ranges(token_idx)
+        if self._replay_log is not None:
+            if not isinstance(
+                self._replay_log, SmartInitialLastRecentlyInsertedKVCacheReplayLog
+            ):
+                raise IndexError(
+                    "Cannot switch on replay logging in the middle of inference run. Call 'prefill'."
                 )
-                for start, np in zip(self.init_length, self.next_position)
-            ]
-            positions = torch.cat(position_parts, dim=0)
+            self._replay_log.update(
+                protected_start=self.protected_start,
+                protected_end=self.protected_end,
+                input_pos=self.input_pos,
+                next_position=self.next_position,
+            )
+            self._replay_log.append_token_chunk(token_idx)
+
+        # If a protected range has just been set in `_update_protected_ranges`,
+        # it must not be used in `extract_index`
+        pstart_copy = [
+            ps if ur else None for ps, ur in zip(self.protected_start, use_range)
+        ]
+        pend_copy = [
+            pe if ur else None for pe, ur in zip(self.protected_end, use_range)
+        ]
+        total_num = key.shape[2]
+        index_kwargs = dict(device=self.device, dtype=torch.int)
+        indexes = extract_index(
+            num=total_num,
+            cache_length=self.cache_length,
+            protected_start=pstart_copy,
+            protected_end=pend_copy,
+            next_position=self.next_position,
+            n_query_groups=self.n_query_groups,
+            **index_kwargs,
+        )
+        k_and_v = None
+        ntp = self.input_pos
+        for positions, off, num in indexes:
             k_and_v = self.kv_buffers.forward(
                 positions=positions,
                 key=key[:, :, off : (off + num), :],
                 value=value[:, :, off : (off + num), :],
             )
+            positions_2d = positions[:, 0, :]
             # Update `token_pos` and `next_positions`
-            for bpos, (start, np) in enumerate(
-                zip(self.init_length, self.next_position)
-            ):
-                num1 = min(num, self.cache_length - np)
-                diff = num - num1
-                ntp = self.input_pos
-                self.token_pos[bpos, np : (np + num1)] = torch.arange(
-                    ntp,
-                    ntp + num1,
-                    **tp_kwargs,
+            for bpos, pos_for_b in enumerate(positions_2d):
+                self.token_pos[bpos, pos_for_b] = torch.arange(
+                    ntp, ntp + num, **index_kwargs
                 )
-                np += num1
-                if diff > 0 or np == self.cache_length:
-                    self.token_pos[bpos, start : (start + diff)] = torch.arange(
-                        ntp + num1,
-                        ntp + num,
-                        **tp_kwargs,
-                    )
-                    np = start + diff
-                self.next_position[bpos] = np
-
-        if self._replay_log is not None:
-            if not isinstance(self._replay_log, DefaultKVCacheReplayLog):
-                raise IndexError(
-                    "Cannot switch on replay logging in the middle of inference run. Call 'prefill'."
-                )
-            self._replay_log.append_token_chunk(token_idx)
+            update_next_position(
+                cache_length=self.cache_length,
+                positions=positions_2d,
+                protected_start=self.protected_start,
+                protected_end=self.protected_end,
+                next_position=self.next_position,
+            )
+            ntp += num
         return k_and_v
 
-    def _set_init_length(self, token_idx: torch.Tensor):
-        batch_size, max_init_length = token_idx.shape
-        max_init_length = max(
+    def _update_protected_ranges(
+        self,
+        token_idx: torch.Tensor,
+    ) -> List[bool]:
+        batch_size, max_range_length = token_idx.shape
+        # Note that for batch positions where the range is not yet determined,
+        # the current cache position is `self.input_pos % self.cache_length`.
+        max_range_length = max(
             min(
-                max_init_length,
+                max_range_length,
                 int(self.cache_length * self.max_initial_fraction),
             ),
             1,
         )
-        self.init_length = []
-        for bpos, tokens in enumerate(token_idx):
-            tokens = tokens.tolist()
-            try:
-                num_left_pad = next(
-                    i for i, t in enumerate(tokens) if t != self._pad_id
-                )
+        if self.protected_start is None:
+            self.protected_start = [None] * batch_size
+            self.protected_end = [None] * batch_size
+        use_range = [pstart is not None for pstart in self.protected_start]
+        for bpos, (tokens, pstart, pend) in enumerate(
+            zip(token_idx, self.protected_start, self.protected_end)
+        ):
+            if pstart is None:
+                # Protected range not yet determined
+                tokens = tokens.tolist()
+                if self.range_is_prefix:
+                    num_left_pad = 0  # Ignore padding tokens
+                else:
+                    try:
+                        num_left_pad = next(
+                            i for i, t in enumerate(tokens) if t != self._pad_id
+                        )
+                    except StopIteration:
+                        # All tokens are padding
+                        continue
                 tokens = tokens[num_left_pad:]
                 decoded = self.tokenizer.decode(tokens, skip_special_tokens=True)
                 match = re.search(self.end_initial_regex, decoded)
-            except StopIteration:
-                print(
-                    f"SmartInitialLastRecentlyInsertedKVCache._set_init_length (bpos={bpos}): Sequence is all padding"
-                )
-                num_left_pad = None
-                match = None
-                decoded = None
-            if match is not None:
-                raw_length = match.end(0) if self.include_end_string else match.start(0)
-                init_encoded = encode(self.tokenizer, decoded[:raw_length])
-                new_length = len(init_encoded)
-                try:
-                    diff_pos = next(
-                        i
-                        for i, (t0, t1) in enumerate(
-                            zip(init_encoded, tokens[:new_length])
-                        )
-                        if t0 != t1
+                if match is not None:
+                    raw_length = (
+                        match.end(0) if self.include_end_string else match.start(0)
                     )
-                    # Can happen if `raw_length` hits in the middle of a token
-                    if diff_pos < new_length - 2:
-                        raise IndexError(
-                            "Error mapping match raw position back to token position:"
-                            "Too many tokens are different at the end:\n"
-                            f"Raw initial part:\n{decoded[:raw_length]}\n"
-                            f"Encoded initial part:\n{init_encoded}\n"
-                            f"Corresponding initial token sequence:\n{tokens[:new_length]}"
+                    init_encoded = encode(self.tokenizer, decoded[:raw_length])
+                    new_length = len(init_encoded)
+                    try:
+                        diff_pos = next(
+                            i
+                            for i, (t0, t1) in enumerate(
+                                zip(init_encoded, tokens[:new_length])
+                            )
+                            if t0 != t1
                         )
-                    else:
-                        new_length = max(diff_pos, 1)
-                except StopIteration:
-                    pass
-                new_length = min(new_length + num_left_pad, max_init_length)
-            else:
-                new_length = max_init_length
-            self.init_length.append(new_length)
+                        # Can happen if `raw_length` hits in the middle of a token
+                        if diff_pos < new_length - 2:
+                            raise IndexError(
+                                "Error mapping match raw position back to token position:"
+                                "Too many tokens are different at the end:\n"
+                                f"Raw initial part:\n{decoded[:raw_length]}\n"
+                                f"Encoded initial part:\n{init_encoded}\n"
+                                f"Corresponding initial token sequence:\n{tokens[:new_length]}"
+                            )
+                        else:
+                            new_length = max(diff_pos, 1)
+                    except StopIteration:
+                        pass
+                    new_length = min(new_length, max_range_length)
+                else:
+                    new_length = min(max_range_length, len(tokens))
+                pstart = (self.input_pos + num_left_pad) % self.cache_length
+                pend = pstart + new_length
+                if pend > self.cache_length:
+                    pend -= self.cache_length
+                assert pstart != pend, (pstart, pend, self.cache_length)
+                self.protected_start[bpos] = pstart
+                self.protected_end[bpos] = pend
+        return use_range
 
     def _prefill_internal(
         self,
@@ -450,7 +646,9 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
         value: torch.Tensor,
         token_idx: torch.Tensor,
     ):
-        self._set_init_length(token_idx)
+        self.protected_start = None
+        self.protected_end = None
+        self._update_protected_ranges(token_idx)
         init_length = key.shape[2]
         self.kv_buffers.prefill(key, value)
         if init_length < self.cache_length:
@@ -460,7 +658,10 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
                 init_length,
                 self.cache_length,
             )  # Sanity check
-            self.next_position = self.init_length.copy()
+            self.next_position = [
+                0 if pstart is None or 0 < pstart < pend else pend
+                for pstart, pend in zip(self.protected_start, self.protected_end)
+            ]
         self.token_pos[: self.batch_size, :init_length] = (
             torch.arange(
                 init_length,
@@ -480,7 +681,9 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
                 max_initial_fraction=self.max_initial_fraction,
                 include_end_string=self.include_end_string,
                 pad_id=self._pad_id,
-                init_length=self.init_length,
+                range_is_prefix=self.range_is_prefix,
+                protected_start=self.protected_start,
+                protected_end=self.protected_end,
             )
 
     def token_positions(self) -> torch.Tensor:
@@ -489,6 +692,11 @@ class SmartInitialLastRecentlyInsertedKVCache(KVCacheWithBuffers):
             .unsqueeze(1)
             .expand(-1, self.n_query_groups, -1)
         )
+
+    def _reset(self):
+        super()._reset()
+        self.protected_start = None
+        self.protected_end = None
 
     def size_estimate(self) -> Tuple[int, Dict[str, int]]:
         tk_p = bitsize_of(self.token_pos)

--- a/keys_values/kvcache/test_utils_advanced.py
+++ b/keys_values/kvcache/test_utils_advanced.py
@@ -131,8 +131,15 @@ def load_tokenizer(
     """
     if cache_dir is None:
         cache_dir = os.getenv("HF_HOME", "./test_tokenizer")
-
-    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+    if os.path.exists(cache_dir):
+        print(
+            f"Detected tokenizer cache at {cache_dir}, will not access internet."
+            " If this fails, remove this directory and try again."
+        )
+        kwargs = dict(local_files_only=True)
+    else:
+        kwargs = dict()
+    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir, **kwargs)
     return tokenizer
 
 

--- a/keys_values/utils.py
+++ b/keys_values/utils.py
@@ -367,7 +367,7 @@ def encode(
     tokenizer: Union[Tokenizer, HFTokenizer],
     s: str,
     **kwargs,
-) -> List[int]:
+) -> Union[List[int], torch.Tensor]:
     if isinstance(tokenizer, Tokenizer):
         tokenizer = tokenizer.processor
     result = tokenizer.encode(s, **kwargs)

--- a/test/kvcache/test_smart_lastrec.py
+++ b/test/kvcache/test_smart_lastrec.py
@@ -149,6 +149,7 @@ def test_smart_lastrec_update_protected_ranges(
         end_initial_regex=smart_lastrec_info.end_initial_regex,
         max_initial_fraction=smart_lastrec_info.max_initial_fraction,
         include_end_string=smart_lastrec_info.include_end_string,
+        range_is_prefix=False,
         device=device,
         dtype=dtype,
     )
@@ -405,6 +406,7 @@ def test_smart_lastrec_update_ranges_several_chunks(
         end_initial_regex=smart_lastrec_info.end_initial_regex,
         max_initial_fraction=smart_lastrec_info.max_initial_fraction,
         include_end_string=smart_lastrec_info.include_end_string,
+        range_is_prefix=False,
         device=device,
         dtype=dtype,
     )

--- a/test/kvcache/test_smart_lastrec.py
+++ b/test/kvcache/test_smart_lastrec.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import replace
+from functools import reduce
+import operator
 from typing import Optional, List, Dict, Tuple
 
 import pytest
@@ -95,14 +97,14 @@ def sample_slot_values(
         ("helmet", "ruler_mv", None, 4096, [28, 28]),
     ],
 )
-def test_smart_lastrec_set_init_length(
+def test_smart_lastrec_update_protected_ranges(
     data_name: str,
     dataset_key: Optional[str],
     head_model: Optional[str],
     cache_length: int,
     expected_init_length: List[int],
 ):
-    seed = 31415927
+    seed = 31415927 + reduce(operator.mul, expected_init_length, 1)
     torch.random.manual_seed(seed)
     num_repeats = 1
     batch_size = len(expected_init_length)
@@ -168,19 +170,32 @@ def test_smart_lastrec_set_init_length(
         encoded_seqs = [
             encode(tokenizer, seq, return_tensors="pt").squeeze(0) for seq in sequences
         ]
+        # We also append "xyz" a random number of times on the left. Need to be
+        # careful with BOS and EOS tokens
+        bogus_tokens = encode(
+            tokenizer,
+            "xyz",
+            return_tensors="pt",
+            add_special_tokens=False,
+        )
+        random_left = [
+            bogus_tokens.expand(num, -1).flatten()
+            for num in torch.randint(0, 8, (batch_size,)).tolist()
+        ]
+        lengths = [x.numel() + y.numel() for x, y in zip(encoded_seqs, random_left)]
+        max_length = max(lengths)
+        num_left_pad = [max_length - l for l in lengths]
         kwargs = dict(dtype=encoded_seqs[0].dtype)
-        max_length = max([x.numel() for x in encoded_seqs])
-        num_left_pad = [max_length - x.numel() for x in encoded_seqs]
         input_ids = torch.cat(
             [
-                torch.cat((torch.zeros(nlp, **kwargs), x)).unsqueeze(0)
-                for x, nlp in zip(encoded_seqs, num_left_pad)
+                torch.cat((torch.zeros(nlp, **kwargs), x[0:1], y, x[1:])).unsqueeze(0)
+                for x, y, nlp in zip(encoded_seqs, random_left, num_left_pad)
             ],
             dim=0,
         )
         if max_length > cache_length:
             input_ids = input_ids[:, :cache_length]
-        # Prefill call to determine `cache.init_length`
+        # Prefill call to determine `cache.protected_*`
         cache.reset()
         num = input_ids.shape[1]
         key, value = random_keys_values(
@@ -202,17 +217,253 @@ def test_smart_lastrec_set_init_length(
             ),
             1,
         )
-        _expected = [
-            min(x + y, max_init_length)
-            for x, y in zip(expected_init_length, num_left_pad)
+        _expected_start = num_left_pad
+        _expected_end = [
+            nlp + min(rn.numel() + el, max_init_length)
+            for el, nlp, rn in zip(expected_init_length, num_left_pad, random_left)
         ]
         print(
-            f"cache.init_length = {cache.init_length}\nmax_init_length = {max_init_length}"
+            f"cache.protected_start = {cache.protected_start}\ncache.protected_end = {cache.protected_end}"
         )
-        for i, (tokens, il, nlp) in enumerate(
-            zip(input_ids, cache.init_length, num_left_pad)
+        for i, (tokens, pstart, pend) in enumerate(
+            zip(input_ids, cache.protected_start, cache.protected_end)
         ):
             print(
-                f"\n[{i}]: {tokenizer.decode(tokens[nlp:il], skip_special_tokens=True)}"
+                f"\n[{i}]: {tokenizer.decode(tokens[pstart:pend], skip_special_tokens=True)}"
             )
-        assert _expected == cache.init_length, (_expected, cache.init_length)
+        assert _expected_start == cache.protected_start, (
+            _expected_start,
+            cache.protected_start,
+        )
+        assert _expected_end == cache.protected_end, (
+            _expected_end,
+            cache.protected_end,
+        )
+
+
+@pytest.mark.parametrize(
+    "data_name, dataset_key, head_model, expected_init_length",
+    [
+        ("longbench_v2", None, CrossEntropyOnLogits.NAME, [15, 15, 15]),
+        ("helmet", "nq", None, [30, 30, 30]),
+        ("helmet", "trivia_qa", None, [30]),
+        ("helmet", "hotpot_qa", None, [30, 30]),
+        ("helmet", "pop_qa", None, [30, 30, 30, 30]),
+        ("helmet", "alce_asqa", None, [145, 145, 145, 145, 145]),
+        ("helmet", "alce_qampari", None, [145, 145, 145]),
+        ("helmet", "ms_macro", None, [71, 71]),
+        ("helmet", "trec_coarse", None, [31, 31, 31]),
+        ("helmet", "trec_fine", None, [31]),
+        ("helmet", "nlu", None, [31, 31, 31, 31]),
+        ("helmet", "banking77", None, [31, 31, 31]),
+        ("helmet", "clinc150", None, [31, 31, 31]),
+        ("helmet", "narrative_qa", None, [40, 40, 40, 40]),
+        ("helmet", "infinite_bench_qa", None, [28, 28]),
+        ("helmet", "infinite_bench_mc", None, [56, 56, 56]),
+        ("helmet", "infinite_bench_sum", None, [56]),
+        ("helmet", "multi_lex_sum", None, [61, 61, 61, 61]),
+        ("helmet", "json_kv", None, [16, 16, 16]),
+        ("helmet", "ruler_mk_needle", None, [28, 28]),
+        ("helmet", "ruler_mk_uuid", None, [28, 28]),
+        ("helmet", "ruler_mv", None, [28, 28]),
+    ],
+)
+def test_smart_lastrec_update_ranges_several_chunks(
+    data_name: str,
+    dataset_key: Optional[str],
+    head_model: Optional[str],
+    expected_init_length: List[int],
+):
+    seed = 31415927 + reduce(operator.mul, expected_init_length, 1)
+    torch.random.manual_seed(seed)
+    batch_size = len(expected_init_length)
+    device = torch.device("cpu")
+    dtype = torch.float16
+
+    # Create tokenizer and dataset
+    tokenizer = load_tokenizer()
+    if data_name == "longbench_v2":
+        data = LongBenchV2()
+        assert head_model is not None
+        instruction_template, slot_names = get_template_longbench_v2(head_model)
+    else:
+        data = Helmet(dataset_key=dataset_key)
+        assert dataset_key is not None
+        instruction_template, slot_names = get_template_helmet(dataset_key)
+    smart_lastrec_info = replace(
+        data.smart_lastrec_info(tokenizer),
+        max_initial_fraction=0.99,
+    )
+
+    # Create input sequences
+    sequences = []
+    for _ in range(batch_size):
+        slot_kwargs = sample_slot_values(slot_names, dataset_key)
+        sequences.append(instruction_template.format(**slot_kwargs))
+    # Tokenize and pad sequences. We do left padding, the number of
+    # pad tokens need to be added to `expected_init_length`
+    encoded_seqs = [
+        encode(tokenizer, seq, return_tensors="pt").squeeze(0) for seq in sequences
+    ]
+    # We also append "xyz" a random number of times on the left. Need to be
+    # careful with BOS and EOS tokens
+    bogus_tokens = encode(
+        tokenizer,
+        "xyz",
+        return_tensors="pt",
+        add_special_tokens=False,
+    )
+    random_left = [
+        bogus_tokens.expand(num, -1).flatten()
+        for num in torch.randint(0, 8, (batch_size,)).tolist()
+    ]
+    lengths = [x.numel() + y.numel() for x, y in zip(encoded_seqs, random_left)]
+    max_length = max(lengths)
+    num_left_pad = [max_length - l for l in lengths]
+    kwargs = dict(dtype=encoded_seqs[0].dtype)
+    input_ids = torch.cat(
+        [
+            torch.cat((torch.zeros(nlp, **kwargs), x[0:1], y, x[1:])).unsqueeze(0)
+            for x, y, nlp in zip(encoded_seqs, random_left, num_left_pad)
+        ],
+        dim=0,
+    )
+    # Determine cache length
+    cache_length = max_length + 16
+    chunk_size = max_length + 1
+    # Prepare data so that some sequences move further down in chunks
+    parts = []
+    bogus_token = encode(
+        tokenizer,
+        "q",
+        return_tensors="pt",
+        add_special_tokens=False,
+    )
+    expected_start = []
+    expected_end = []
+    expected_token_pos = []
+    for shift_chunks, tokens, nlp, el, rn in zip(
+        torch.randint(0, 3, (batch_size,)).tolist(),
+        input_ids,
+        num_left_pad,
+        expected_init_length,
+        random_left,
+    ):
+        e_start = nlp
+        e_end = nlp + rn.numel() + el
+        if shift_chunks == 0:
+            fill_sz = cache_length + chunk_size
+            fill_right = bogus_token.expand(fill_sz, -1).flatten()
+            new_tokens = torch.cat((tokens[:-1], fill_right, tokens[-1:]))
+            expected_start.append(e_start)
+            expected_end.append(e_end)
+            expected_token_pos.append(list(range(e_start, e_end)))
+        elif shift_chunks == 1:
+            off = cache_length
+            pad_left = torch.zeros(off, **kwargs)
+            fill_sz = chunk_size
+            fill_right = bogus_token.expand(fill_sz, -1).flatten()
+            new_tokens = torch.cat((pad_left, tokens[:-1], fill_right, tokens[-1:]))
+            expected_start.append(e_start)
+            expected_end.append(e_end)
+            expected_token_pos.append(list(range(e_start + off, e_end + off)))
+        else:
+            assert shift_chunks == 2, (shift_chunks,)
+            off = cache_length + chunk_size
+            pad_left = torch.zeros(off, **kwargs)
+            new_tokens = torch.cat((pad_left, tokens))
+            expected_start.append((e_start + chunk_size) % cache_length)
+            expected_end.append((e_end + chunk_size) % cache_length)
+            expected_token_pos.append(list(range(e_start + off, e_end + off)))
+        parts.append(new_tokens.unsqueeze(0))
+    input_ids = torch.cat(parts, dim=0)
+
+    # Create KV cache
+    vocab_size = tokenizer.vocab_size + len(tokenizer.additional_special_tokens)
+    config = Config(
+        n_layer=1,
+        n_head=8,
+        n_query_groups=4,
+        n_embd=8 * 64,
+        block_size=2 * cache_length,
+        vocab_size=vocab_size,
+        rotary_percentage=1,
+    )
+    params = KVCacheParams.from_config(
+        config=config,
+        max_batch_size=batch_size,
+        cache_length=cache_length,
+        dtype=dtype,
+    )
+    # Overwrite `max_initial_fraction`, because we use short cache lengths
+    cache = SmartInitialLastRecentlyInsertedKVCache.from_config(
+        config,
+        max_batch_size=batch_size,
+        cache_length=cache_length,
+        block_idx=0,
+        tokenizer=tokenizer,
+        end_initial_regex=smart_lastrec_info.end_initial_regex,
+        max_initial_fraction=smart_lastrec_info.max_initial_fraction,
+        include_end_string=smart_lastrec_info.include_end_string,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Prefill, then two chunks
+    cache.reset()
+    input_pos = 0
+    fin_sz = input_ids.shape[-1] - cache_length - chunk_size
+    for num in (cache_length, chunk_size, fin_sz):
+        key, value = random_keys_values(
+            params,
+            num=num,
+            device=device,
+        )
+        query = random_tensor(
+            params,
+            num=num,
+            is_query=True,
+            device=device,
+        )
+        print(f"input_pos = {input_pos}, num = {num}")
+        cache.forward(
+            query,
+            key,
+            value,
+            input_ids[:, input_pos : (input_pos + num)],
+        )
+        input_pos += num
+    # Compare
+    print(
+        f"cache.protected_start: {cache.protected_start}\ncache.protected_end:   {cache.protected_end}"
+    )
+    for i, (tokens, p_start, p_end, token_pos) in enumerate(
+        zip(
+            input_ids,
+            cache.protected_start,
+            cache.protected_end,
+            cache.token_positions()[:, 0, :],
+        )
+    ):
+        if p_start < p_end:
+            t_start = token_pos[p_start].item()
+            t_end = token_pos[p_end - 1].item() + 1
+            print(
+                f"\n[{i}]: {tokenizer.decode(tokens[t_start:t_end], skip_special_tokens=True)}"
+            )
+    assert expected_start == cache.protected_start, (
+        expected_start,
+        cache.protected_start,
+    )
+    assert expected_end == cache.protected_end, (expected_end, cache.protected_end)
+    for p_start, p_end, token_pos, exp_tp in zip(
+        cache.protected_start,
+        cache.protected_end,
+        cache.token_positions()[:, 0, :],
+        expected_token_pos,
+    ):
+        if p_start < p_end:
+            tp = token_pos[p_start:p_end].tolist()
+        else:
+            tp = token_pos[p_start:].tolist() + token_pos[:p_end].tolist()
+        assert tp == exp_tp, (tp, exp_tp, p_start, p_end)


### PR DESCRIPTION
… ranges (need not be prefix, excludes left padding, can wrap around)

Note: This feature is not switched on by default (so `kv_cache.range_is_prefix` is `True` by def, which is the old case). This is because initial experiments did not show improvements.

This should be revisited. Why is it useful to keep KV information in the cache for initial left padding tokens?

Closes #130.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
