### PR TITLE
Fix FlashInfer attention weights for q_len=1 (#96)

### DIFF
--- a/keys_values/attention/flashinfer_ops.py
+++ b/keys_values/attention/flashinfer_ops.py
@@ -247,6 +247,14 @@ def sdpa_decode(
             "Vendored FlashInfer kernels are not available. " f"Error: {_load_error}"
         )
 
+    # The single query token is the last position, so causal masking is a
+    # no-op: it must attend to all of the KV cache. With return_weights=True,
+    # the tiled kernels are used, which default the query position to 0 if
+    # `input_pos` is not given, so `causal=True` would mask out everything
+    # except KV position 0 (issue #96). Pass `causal=False` in this case.
+    # With return_weights=False, keep `causal=True`, since the native
+    # FlashInfer decode kernel (which treats the query as the last position)
+    # is only dispatched for causal attention.
     attn_outputs, attn_weights = _ops.sdpa_decode(
         query,
         key,
@@ -255,7 +263,7 @@ def sdpa_decode(
         None,  # token_positions
         None,  # input_pos
         -1,  # sliding_window_size
-        True,  # causal
+        not return_weights,  # causal
         return_weights,
     )
     if return_weights:

--- a/test/attention/test_attn_weights.py
+++ b/test/attention/test_attn_weights.py
@@ -149,9 +149,7 @@ def eager_weights(query, key, scale, input_pos, token_positions):
 def get_variants(q_len: int):
     variants = (pytorch_reference_weights, eager_weights, flexatt_weights)
     names = ("PyTorch reference", "eager", "FlexAttention")
-    # TODO: Currently, FlashInfer is skipped for q_len = 1, because there is
-    # some bug. Fix it and remove this exclusion.
-    if _get_flashinfer_sdpa() is not None and q_len > 1:
+    if _get_flashinfer_sdpa() is not None:
         variants += (flashinfer_weights,)
         names += ("FlashInfer",)
     return variants, names


### PR DESCRIPTION
The q_len=1 decode path with return_attn_weights=True routes to the tiled CUDA kernels, which default the query position to 0 when input_pos is not given. With causal=True this masked out every KV entry except position 0, producing one-hot attention weights and breaking token generation with H2O-style cache strategies.

Since the single query token is the last position, causal masking is a no-op (it must attend to the whole KV cache). Pass causal=False when return_weights=True. The return_weights=False path keeps causal=True so it still dispatches to the fast native FlashInfer decode kernel.

Also remove the q_len > 1 exclusion for FlashInfer in test_attn_weights.py; all q_len=1 cases now pass.

> REPLACE THIS TEXT BLOCK
>
> Describe the reason for this change, what the solution is, and any
> important design decisions you made. 
>
> Remember to follow the [CONTRIBUTING GUIDE] for any code you submit.
>
> [CONTRIBUTING GUIDE]: https://github.com/awslabs/keys_values/blob/main/CONTRIBUTING.md

Closes #<issue number here>.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
