### PR TITLE
Async cpu transfer

### DIFF
--- a/keys_values/finetune/args.py
+++ b/keys_values/finetune/args.py
@@ -231,6 +231,10 @@ class GradientArgs:
         cachecp_pin_memory: If `True`, the CPU memory pages for KV cache
             checkpoints are pinned. This can run faster, but also needs more
             real CPU memory.
+        async_cpu_transfer: If `True`, CPU -> GPU and GPU -> CPU transfers
+            during gradient computation are run on separate CUDA streams, in
+            parallel with GPU computation. Requires `layercp_pin_memory=True`
+            and `cachecp_pin_memory=True`. Defaults to `False`.
         debug_print_annotations: If `True`, debug logging during `backward`
             computations are written which allow to track annotations for
             `autograd` saved tensors hooks.
@@ -245,6 +249,7 @@ class GradientArgs:
     max_match_trials_pack_arg: Optional[int] = None
     layercp_pin_memory: bool = True
     cachecp_pin_memory: bool = True
+    async_cpu_transfer: bool = False
     debug_print_annotations: bool = False
 
     def __post_init__(self):
@@ -262,6 +267,13 @@ class GradientArgs:
         elif self.cachecp_qname not in SUPPORTED_QUANTIZERS:
             raise ValueError(
                 f"cachecp_qname = {self.cachecp_qname} not supported, must be in {SUPPORTED_QUANTIZERS}"
+            )
+        if self.async_cpu_transfer and not (
+            self.layercp_pin_memory and self.cachecp_pin_memory
+        ):
+            raise ValueError(
+                "async_cpu_transfer=True requires layercp_pin_memory=True "
+                "and cachecp_pin_memory=True"
             )
         _check_int(self.max_match_trials_pack_arg, "max_match_trials_pack_arg")
 

--- a/keys_values/finetune/longcontext_full.py
+++ b/keys_values/finetune/longcontext_full.py
@@ -1189,6 +1189,7 @@ def wrap_gpt_model(
             cache_kwargs=cache_kwargs,
             train_cache_kwargs=train_cache_kwargs,
             backward_tmp_array_limit_gb=backward_tmp_array_limit_gb,
+            async_cpu_transfer=grad.async_cpu_transfer,
             layercp_pin_memory=grad.layercp_pin_memory,
             cachecp_pin_memory=grad.cachecp_pin_memory,
             autograd_hooks_kwargs=autograd_hooks_kwargs,

--- a/keys_values/kvcache/gradient/accumulate.py
+++ b/keys_values/kvcache/gradient/accumulate.py
@@ -15,7 +15,7 @@ from collections import Counter
 import contextlib
 from functools import partial
 from itertools import accumulate
-from typing import List, Optional, Dict, Any, Tuple
+from typing import List, Optional, Dict, Any, Tuple, Iterable
 
 import torch
 
@@ -73,6 +73,75 @@ def checkpoint_hook(
 
 def copy_requires_grad(x: torch.Tensor) -> torch.Tensor:
     return x.clone().detach().requires_grad_(True)
+
+
+class DoubleBuffer:
+    """
+    Maintains two `torch.Tensor` objects, where in each cycle, one of them
+    is read, the other is written. With :meth:`flip`, the cycle is switched, so
+    that write becomes read and vice versa. An object is first written, then read
+    after the flip, then overwritten after the next flip.
+
+    If `single_only=True`, we only maintain one object. This is a dummy to be
+    used if no double buffering is needed.
+    """
+
+    def __init__(self, single_only: bool = False):
+        self._buffers: List[Optional[torch.Tensor]] = (
+            [None] if single_only else [None, None]
+        )
+        self._write_pos = 0
+        self._single_only = single_only
+
+    def write(self, x: torch.Tensor):
+        self._buffers[self._write_pos] = x
+
+    def read(self) -> Optional[torch.Tensor]:
+        return self._buffers[0 if self._single_only else 1 - self._write_pos]
+
+    def flip(self):
+        if not self._single_only:
+            self._write_pos = 1 - self._write_pos
+
+
+def stream_decorator(s: Optional[torch.cuda.Stream]) -> Any:
+    return torch.cuda.stream(s) if s is not None else contextlib.nullcontext()
+
+
+def flip_all(
+    pair_cell_inputs: DoubleBuffer,
+    pair_head_gradients_top: DoubleBuffer,
+    pair_head_gradients_bottom: DoubleBuffer,
+    pair_k_buffers: List[DoubleBuffer],
+    pair_v_buffers: List[DoubleBuffer],
+):
+    pair_cell_inputs.flip()
+    pair_head_gradients_top.flip()
+    pair_head_gradients_bottom.flip()
+    for elem in pair_k_buffers:
+        elem.flip()
+    for elem in pair_v_buffers:
+        elem.flip()
+
+
+def main_stream_waits_for_events(events: List[torch.Event]):
+    """
+    The current (main) stream waits for `events` to have happened. This is a
+    GPU-side ordering constraint, the host thread is not blocked.
+    """
+    for event in events:
+        torch.cuda.current_stream().wait_event(event)
+    events.clear()
+
+
+def streams_wait_for_event(
+    streams: Iterable[Optional[torch.cuda.Stream]],
+    event: Optional[torch.Event],
+):
+    if event is not None:
+        for s in streams:
+            if s is not None:
+                s.wait_event(event)
 
 
 def select_entries(
@@ -486,12 +555,76 @@ class GradientAccumulator:
         else:
             return None
 
+    def _load_from_cpu(
+        self,
+        col_idx: int,
+        host_to_device_stream: Optional[torch.cuda.Stream],
+        pair_cell_inputs: DoubleBuffer,
+        pair_head_gradients_top: DoubleBuffer,
+        pair_k_buffers: List[DoubleBuffer],
+        pair_v_buffers: List[DoubleBuffer],
+        events_for_wait: List[torch.Event],
+        get_inputs_slice: GetInputSlice,
+        get_head_gradients_slice: GetInputSlice,
+        chunk_idxs: List[int],
+        cache_lengths: List[int],
+    ):
+        """
+        Loads inputs for the cell at `col_idx - 1` from CPU, writing into the
+        double buffers. If `host_to_device_stream` is given, this runs on that
+        stream, and an event is appended to `events_for_wait` which fires once
+        the loads are complete.
+        """
+        if col_idx > 0:
+            # Prefetching
+            start, end = self.inputs_ranges[col_idx - 1]
+            with stream_decorator(host_to_device_stream):
+                pair_cell_inputs.write(get_inputs_slice(start, end))
+                pair_head_gradients_top.write(get_head_gradients_slice(start, end))
+                if col_idx > 1:
+                    # Note: It is `chunk_idxs[col_idx - 1]`, since
+                    # `chunk_idxs[0] == 0` is a dummy entry
+                    k_buffs, v_buffs = self._get_checkpoints(
+                        chunk_idx=chunk_idxs[col_idx - 1],
+                        cache_lengths=cache_lengths,
+                    )
+                    for trg, src in zip(pair_k_buffers, k_buffs):
+                        trg.write(src)
+                    for trg, src in zip(pair_v_buffers, v_buffs):
+                        trg.write(src)
+                if host_to_device_stream is not None:
+                    events_for_wait.append(host_to_device_stream.record_event())
+
+    def _write_to_cpu(
+        self,
+        col_idx: int,
+        device_to_host_stream: Optional[torch.cuda.Stream],
+        pair_head_gradients_bottom: DoubleBuffer,
+        events_for_wait: List[torch.Event],
+        write_head_gradients_slice: WriteOutputsSlice,
+    ):
+        """
+        Writes the bottom head gradients for the cell at `col_idx + 1` to CPU,
+        reading from the double buffer. If `device_to_host_stream` is given,
+        this runs on that stream, and an event is appended to
+        `events_for_wait` which fires once the write is complete.
+        """
+        if col_idx < len(self.inputs_ranges) - 1:
+            # Write back bottom head gradient (delayed by one iteration)
+            start, _ = self.inputs_ranges[col_idx + 1]
+            with stream_decorator(device_to_host_stream):
+                write_head_gradients_slice(start, pair_head_gradients_bottom.read())
+                if device_to_host_stream is not None:
+                    events_for_wait.append(device_to_host_stream.record_event())
+
     def run(
         self,
         model_part: CellBlocks,
         get_inputs_slice: GetInputSlice,
         get_head_gradients_slice: GetInputSlice,
         write_head_gradients_slice: WriteOutputsSlice,
+        device_to_host_stream: Optional[torch.cuda.Stream] = None,
+        host_to_device_stream: Optional[torch.cuda.Stream] = None,
         record_gpu_memory_snapshots: Optional[RecordGPUMemory] = None,
     ):
         """
@@ -507,6 +640,15 @@ class GradientAccumulator:
         to the same checkpoint object. We guarantee that any slice is read
         before it is written to.
 
+        If `device_to_host_stream` and `host_to_device_stream` are provided,
+        we try to run CPU -> GPU (`host_to_device_stream`) and GPU -> CPU
+        (`device_to_host_stream`) transfers in parallel with GPU computation
+        (main stream). This is done using double buffering: loads from CPU
+        are prefetched (for the next cell), stores to CPU are delayed (from
+        the previous cell). This works only if all CPU buffers written to or
+        read from are pinned. Stream ordering is expressed with GPU-side
+        events, the host thread is never blocked.
+
         Args:
             model_part: Represents layers of model for the cell
             get_inputs_slice: Function `f(start, end)` which returns a slice
@@ -517,10 +659,17 @@ class GradientAccumulator:
             write_head_gradients_slice: Function `f(start, value)` which writes
                 a slice `range(start, end)` of the head gradients for output
                 of layer `first_layer_idx - 1`.
+            device_to_host_stream: See above.
+            host_to_device_stream: See above.
 
         """
         assert self.replay_logs is not None, "Call 'run_head_model' for a new batch"
         assert self._batch_size is not None
+        use_multi_streams = device_to_host_stream is not None
+        if use_multi_streams != (host_to_device_stream is not None):
+            raise ValueError(
+                "Either both or none of device_to_host_stream, host_to_device_stream must be given"
+            )
         first_layer_idx = model_part.first_layer_idx
         num_layers = model_part.num_layers
         self._check_run_args(first_layer_idx, num_layers)
@@ -585,34 +734,121 @@ class GradientAccumulator:
             chunk_idxs = [0]
             if self.do_checkpointing:
                 chunk_idxs += self._kv_cache_checkpoints[0].chunk_numbers
+            num_cells = len(self.inputs_ranges)
             if self._verbose_more:
                 print(f"Process row of {len(chunk_idxs)} cells in reverse order")
 
-            for col_idx, (first_chunk_idx, num_chunks, (start, end)) in reversed(
-                list(
-                    enumerate(zip(chunk_idxs, self.chunks_per_cell, self.inputs_ranges))
-                )
+            # Double buffering with multiple streams. Buffers are used for
+            # (1) inputs to gradient computation, loaded from CPU by
+            # `_load_from_cpu`, and (2) outputs of gradient computation,
+            # written to CPU by `_write_to_cpu`. The cycle of (1) buffers is
+            # opposite to the cycle of (2) buffers.
+            pair_cell_inputs = DoubleBuffer(single_only=not use_multi_streams)
+            pair_head_gradients_top = DoubleBuffer(single_only=not use_multi_streams)
+            pair_k_buffers = [
+                DoubleBuffer(single_only=not use_multi_streams)
+                for _ in range(num_layers)
+            ]
+            pair_v_buffers = [
+                DoubleBuffer(single_only=not use_multi_streams)
+                for _ in range(num_layers)
+            ]
+            pair_head_gradients_bottom = DoubleBuffer(single_only=not use_multi_streams)
+            events_for_wait: List[torch.Event] = []
+            main_event: Optional[torch.Event] = None
+            if use_multi_streams:
+                # The transfer streams must wait for (a) main stream work
+                # enqueued so far (e.g., `run_head_model`, KV cache checkpoint
+                # computation above, previous row of cells), and (b) previous
+                # writes on the d2h stream (e.g., layer input checkpoints from
+                # the forward pass, head gradients of the previous row), since
+                # the loads below read from the same CPU buffers.
+                ev_main = torch.cuda.current_stream().record_event()
+                ev_d2h = device_to_host_stream.record_event()
+                host_to_device_stream.wait_event(ev_main)
+                host_to_device_stream.wait_event(ev_d2h)
+                device_to_host_stream.wait_event(ev_main)
+            # Load inputs for the last cell (processed first)
+            self._load_from_cpu(
+                num_cells,
+                host_to_device_stream,
+                pair_cell_inputs,
+                pair_head_gradients_top,
+                pair_k_buffers,
+                pair_v_buffers,
+                events_for_wait,
+                get_inputs_slice,
+                get_head_gradients_slice,
+                chunk_idxs,
+                cache_lengths,
+            )
+            main_stream_waits_for_events(events_for_wait)
+            flip_all(
+                pair_cell_inputs,
+                pair_head_gradients_top,
+                pair_head_gradients_bottom,
+                pair_k_buffers,
+                pair_v_buffers,
+            )
+            # Cycle of `_write_to_cpu` state must be opposite to cycle of
+            # `_load_from_cpu` state
+            pair_head_gradients_bottom.flip()
+
+            for col_idx, (first_chunk_idx, num_chunks) in reversed(
+                list(enumerate(zip(chunk_idxs, self.chunks_per_cell)))
             ):
+                if use_multi_streams:
+                    # Transfer streams wait for GPU computation of the
+                    # previous iteration to finish before overwriting (h2d)
+                    # or reading (d2h) buffers involved there
+                    streams_wait_for_event(
+                        (host_to_device_stream, device_to_host_stream),
+                        main_event,
+                    )
+                    main_event = None
+                    # Prefetch inputs for the next cell (`col_idx - 1`), in
+                    # parallel with the computation for cell `col_idx` below
+                    self._load_from_cpu(
+                        col_idx,
+                        host_to_device_stream,
+                        pair_cell_inputs,
+                        pair_head_gradients_top,
+                        pair_k_buffers,
+                        pair_v_buffers,
+                        events_for_wait,
+                        get_inputs_slice,
+                        get_head_gradients_slice,
+                        chunk_idxs,
+                        cache_lengths,
+                    )
+
+                # Write back bottom head gradients of the previous cell
+                # (`col_idx + 1`), in parallel with the computation below
+                self._write_to_cpu(
+                    col_idx,
+                    device_to_host_stream,
+                    pair_head_gradients_bottom,
+                    events_for_wait,
+                    write_head_gradients_slice,
+                )
+
                 # Gather inputs and head gradients:
                 # - Inputs bottom:   cell_inputs
                 # - Inputs left:     k_buffers, v_buffers
                 # - Gradients top:   head_gradients_top
                 # - Gradients right: head_gradients_k, head_gradients_v
-                cell_inputs = copy_requires_grad(get_inputs_slice(start, end))
-                head_gradients_top = get_head_gradients_slice(start, end)
+                cell_inputs = copy_requires_grad(pair_cell_inputs.read())
+                head_gradients_top = pair_head_gradients_top.read()
                 if col_idx == 0:
                     k_buffers = None
                     v_buffers = None
                 else:
-                    # Note: It is `chunk_idxs[col_idx]`, not
-                    # `chunk_idxs[col_idx - 1]`, because `chunk_idxs[0] == 0` is a
-                    # dummy entry
-                    k_buffers, v_buffers = self._get_checkpoints(
-                        chunk_idx=chunk_idxs[col_idx],
-                        cache_lengths=cache_lengths,
-                    )
-                    k_buffers = [copy_requires_grad(x) for x in k_buffers]
-                    v_buffers = [copy_requires_grad(x) for x in v_buffers]
+                    k_buffers = [
+                        copy_requires_grad(k_buff.read()) for k_buff in pair_k_buffers
+                    ]
+                    v_buffers = [
+                        copy_requires_grad(v_buff.read()) for v_buff in pair_v_buffers
+                    ]
 
                 # Forward-backward, using the autograd hooks (if given)
                 scalar_output = None
@@ -638,10 +874,42 @@ class GradientAccumulator:
                         )
 
                     scalar_output.backward()
-                    write_head_gradients_slice(start, cell_inputs.grad)
                     if col_idx > 0:
                         head_gradients_k = [x.grad for x in k_buffers]
                         head_gradients_v = [x.grad for x in v_buffers]
+                    # Written to CPU in the next iteration (`_write_to_cpu`),
+                    # or after the loop for the first cell
+                    pair_head_gradients_bottom.write(cell_inputs.grad)
+                    if use_multi_streams:
+                        # Fires once the computation for this cell is done
+                        main_event = torch.cuda.current_stream().record_event()
+                    else:
+                        # Single stream: Load inputs for the next cell here
+                        # (after the computation, as before)
+                        self._load_from_cpu(
+                            col_idx,
+                            host_to_device_stream,
+                            pair_cell_inputs,
+                            pair_head_gradients_top,
+                            pair_k_buffers,
+                            pair_v_buffers,
+                            events_for_wait,
+                            get_inputs_slice,
+                            get_head_gradients_slice,
+                            chunk_idxs,
+                            cache_lengths,
+                        )
+
+                    # Main stream waits for the transfers dispatched above,
+                    # since the next iteration reads the loaded buffers
+                    main_stream_waits_for_events(events_for_wait)
+                    flip_all(
+                        pair_cell_inputs,
+                        pair_head_gradients_top,
+                        pair_head_gradients_bottom,
+                        pair_k_buffers,
+                        pair_v_buffers,
+                    )
                 finally:
                     del scalar_output
                     del cell_inputs
@@ -676,6 +944,18 @@ class GradientAccumulator:
                                 f"\nAnnotation usage log [{part}; chunks {first_chunk_idx} to {first_chunk_idx + num_chunks - 1}]"
                             )
                             print(self._annotation_usage_logs[first_chunk_idx].report())
+
+            # Write back bottom head gradients for the first cell (the
+            # delayed write scheme has not flushed this one yet)
+            streams_wait_for_event((device_to_host_stream,), main_event)
+            self._write_to_cpu(
+                -1,
+                device_to_host_stream,
+                pair_head_gradients_bottom,
+                events_for_wait,
+                write_head_gradients_slice,
+            )
+            main_stream_waits_for_events(events_for_wait)
 
         finally:
             if self.do_checkpointing:

--- a/keys_values/kvcache/gradient/accumulate.py
+++ b/keys_values/kvcache/gradient/accumulate.py
@@ -698,9 +698,15 @@ class GradientAccumulator:
                 infer_replay_caches,
                 get_inputs_slice,
             )
-            if torch.cuda.is_available():
+            if torch.cuda.is_available() and not use_multi_streams:
                 # Synchronize here to make sure the checkpoints are properly
-                # written to CPU (host), before they are read below
+                # written to CPU (host), before they are read below.
+                # If multiple streams are used, this ordering is expressed
+                # by GPU-side events below instead (the transfer streams
+                # wait for an event recorded on the main stream after the
+                # checkpoint computation), so the host thread need not be
+                # blocked. This matters: profiling shows this synchronize
+                # blocks the host for ~1 second per row of cells.
                 torch.cuda.synchronize()
             # Remove caches (underlying buffers are kept)
             while infer_replay_caches:

--- a/keys_values/kvcache/gradient/checkpoints.py
+++ b/keys_values/kvcache/gradient/checkpoints.py
@@ -527,8 +527,8 @@ class KVCacheBufferDefaultCheckpoints(KVCacheBufferCheckpoints):
         pos: int,
         out: DefaultKVCacheBuffers,
     ):
-        key = self.k[pos][:, ...]
-        value = self.v[pos][:, ...]
+        key = self.k[pos]
+        value = self.v[pos]
         device = out.device
         if device is not None:
             key = key.to(device, non_blocking=True)

--- a/keys_values/kvcache/gradient/main.py
+++ b/keys_values/kvcache/gradient/main.py
@@ -30,7 +30,10 @@ from keys_values.kvcache.consts import SUPPORTED_QUANTIZERS
 from keys_values.kvcache.factory import (
     deallocate_kv_cache_buffers_of_model,
 )
-from keys_values.kvcache.gradient.accumulate import GradientAccumulator
+from keys_values.kvcache.gradient.accumulate import (
+    GradientAccumulator,
+    stream_decorator,
+)
 from keys_values.kvcache.gradient.autograd_hooks import (
     CellComputationAutogradHooks,
     CleanupArraysAutogradHooks,
@@ -231,6 +234,7 @@ class LongContextGradientModel(LongContextInferenceModel):
         cache_kwargs: Optional[Dict[str, Any]] = None,
         train_cache_kwargs: Optional[Dict[str, Any]] = None,
         backward_tmp_array_limit_gb: Optional[TemporaryArrayLimit] = None,
+        async_cpu_transfer: bool = False,
         layercp_pin_memory: bool = False,
         cachecp_pin_memory: bool = False,
         autograd_hooks_kwargs: Optional[Dict[str, Any]] = None,
@@ -296,6 +300,12 @@ class LongContextGradientModel(LongContextInferenceModel):
             backward_tmp_array_limit_gb: Same role as `tmp_array_limit_gb`, but
                 for backward computations. Overrides "tmp_array_limit_gb"
                 entries in `cache_kwargs`, `train_cache_kwargs`.
+            async_cpu_transfer: If `True`, CPU -> GPU and GPU -> CPU transfers
+                (layer input checkpoints, KV cache checkpoints, head
+                gradients) are run on separate CUDA streams, in parallel with
+                GPU computation on the main stream. Requires
+                `layercp_pin_memory=True` and `cachecp_pin_memory=True`.
+                Defaults to `False`.
             layercp_pin_memory: If `True`, the CPU memory pages for layer input
                 checkpoints are pinned. This can run faster, but also needs more
                 real CPU memory.
@@ -385,6 +395,21 @@ class LongContextGradientModel(LongContextInferenceModel):
         self._autograd_hooks_kwargs = autograd_hooks_kwargs
         # Device memory limit for backward computations:
         self._backward_tmp_array_limit_gb = backward_tmp_array_limit_gb
+        if async_cpu_transfer and not (layercp_pin_memory and cachecp_pin_memory):
+            raise ValueError(
+                "async_cpu_transfer=True requires layercp_pin_memory=True and cachecp_pin_memory=True"
+            )
+        if async_cpu_transfer and torch.cuda.is_available():
+            # Stream for GPU -> CPU transfers:
+            self.device_to_host_stream = torch.cuda.Stream()
+            # Stream for CPU -> GPU transfers:
+            self.host_to_device_stream = torch.cuda.Stream()
+        else:
+            self.device_to_host_stream = None
+            self.host_to_device_stream = None
+        # Event marking the end of the most recent layer input checkpoint
+        # copy on `device_to_host_stream`:
+        self._cuda_d2h_copy_event = None
         self.layercp_pin_memory = layercp_pin_memory
         self.cachecp_pin_memory = cachecp_pin_memory
         self._debug_dont_use_autograd_hooks = debug_dont_use_autograd_hooks
@@ -793,18 +818,56 @@ class LongContextGradientModel(LongContextInferenceModel):
         x: torch.Tensor,
         layer_idx: int,
     ):
+        """
+        If `self.device_to_host_stream` is given, the GPU -> CPU copy in
+        `set_checkpoint` runs on this stream, in parallel with GPU
+        computation on the main stream. Stream ordering:
+
+        - `device_to_host_stream` first waits for an event on the main
+          stream, since `x` is produced by computation there (which may have
+          only just been enqueued).
+        - :meth:`_checkpoint_layer_input_sync` is called after the layer has
+          been processed, and makes the main stream wait for the copy. This
+          must happen before the buffer underlying `x` is released.
+
+        We follow:
+        https://docs.pytorch.org/tutorials/intermediate/pinmem_nonblock.html
+
+        """
         if self.training:
             input_pos = self._layer_cp_input_pos.get(layer_idx)
-            self.layer_checkpoints.set_checkpoint(
-                layer_idx=layer_idx,
-                buffers=x,
-                input_pos=0 if input_pos is None else input_pos,
-            )
+            if self.device_to_host_stream is not None:
+                # `x` is produced on the main stream. The copy on
+                # `device_to_host_stream` must not start before that
+                # computation is done.
+                x_ready_event = torch.cuda.current_stream().record_event()
+                self.device_to_host_stream.wait_event(x_ready_event)
+            with stream_decorator(self.device_to_host_stream):
+                self.layer_checkpoints.set_checkpoint(
+                    layer_idx=layer_idx,
+                    buffers=x,
+                    input_pos=0 if input_pos is None else input_pos,
+                )
+                if self.device_to_host_stream is not None:
+                    # Event at end of copy operation
+                    self._cuda_d2h_copy_event = (
+                        self.device_to_host_stream.record_event()
+                    )
             # Need to track `input_pos` separately for each `layer_idx` for which
             # a checkpoint is stored. This works because checkpoints during the
             # forward pass are written left to right.
             if input_pos is not None:
                 self._layer_cp_input_pos[layer_idx] += x.shape[1]
+
+    def _checkpoint_layer_input_sync(
+        self,
+        layer_idx: int,
+    ):
+        if self.training and self.device_to_host_stream is not None:
+            # The main stream must not release or overwrite the source of
+            # the checkpoint copy before the copy is done
+            torch.cuda.current_stream().wait_event(self._cuda_d2h_copy_event)
+            self._cuda_d2h_copy_event = None
 
     def _do_checkpoint_layer_input(self) -> bool:
         return self.training
@@ -935,6 +998,13 @@ class LongContextGradientModel(LongContextInferenceModel):
             raise IndexError(
                 "No KV cache replay logs: Must call `forward` before `backward`"
             )
+        if self.device_to_host_stream is not None:
+            # The forward pass writes layer input checkpoints to CPU on
+            # `device_to_host_stream`. The backward computation below reads
+            # these CPU buffers, so the copies must be visible on the host
+            # before we proceed. This is one blocking synchronization per
+            # batch.
+            torch.cuda.synchronize()
         if self.verbose is not VerbosityLevels.NONE:
             print("\nAllocate storage for backward computation")
 
@@ -1208,6 +1278,8 @@ class LongContextGradientModel(LongContextInferenceModel):
                 get_inputs_slice=partial(get_inputs_slice, layer_idx=first_layer_idx),
                 get_head_gradients_slice=get_head_gradients_slice,
                 write_head_gradients_slice=write_head_gradients_slice,
+                device_to_host_stream=self.device_to_host_stream,
+                host_to_device_stream=self.host_to_device_stream,
                 record_gpu_memory_snapshots=snapshots,
             )
             if self.offload_device is not None:

--- a/keys_values/long_context.py
+++ b/keys_values/long_context.py
@@ -784,6 +784,23 @@ class LongContextInferenceModel(GPTAndHeadModel):
         """
         return False
 
+    def _checkpoint_layer_input_sync(
+        self,
+        layer_idx: int,
+    ):
+        """
+        Callback used together with :meth:`_checkpoint_layer_input`. While the
+        latter is called before the input (all chunks of the current cell) is
+        processed for layer `layer_idx`, this method is called after this
+        processing. Can be used to synchronize streams which have been running
+        in parallel.
+
+        Args:
+            layer_idx: Index of layer which has just been processed
+
+        """
+        pass
+
     def _forward_internal(
         self,
         input_ids: torch.Tensor,
@@ -941,6 +958,10 @@ class LongContextInferenceModel(GPTAndHeadModel):
                         if not compute_loss and is_final_chunk and is_final_layer:
                             # We need the final layer output for the last chunk
                             logits_final_position = y[:, -1:, :].detach()
+                    # Callback which may deal with stream synchronization.
+                    # Must be called before `del embeddings`, since the
+                    # checkpoint copy may still read from `embeddings`.
+                    self._checkpoint_layer_input_sync(block_idx)
                     del embeddings
                     embeddings = torch.cat(new_embed_parts, dim=1)
                     assert embeddings.shape[1] == end - start, (
@@ -1000,6 +1021,7 @@ class LongContextInferenceModel(GPTAndHeadModel):
                         logits_final_position = self.gpt_model.lm_head(
                             logits_final_position
                         )
+                self._checkpoint_layer_input_sync(self.config.n_layer)
 
         if compute_loss:
             if num_target_entries is not None:

--- a/test/kvcache/test_gradient_async.py
+++ b/test/kvcache/test_gradient_async.py
@@ -1,0 +1,227 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import replace
+from itertools import product
+
+import torch
+import pytest
+
+from litgpt.utils import _RunIf
+
+from keys_values.attention.flex_attention import FlexAttentionArgs
+from keys_values.config import Config
+from keys_values.finetune.utils import may_match_twice_flex_attention_sdpa
+from keys_values.head_model import CrossEntropyOnLogits
+from keys_values.head_model_factory import HeadModelFactory
+from keys_values.kvcache.base import KVCacheParams
+from keys_values.kvcache.gradient.main import LongContextGradientModel
+from keys_values.kvcache.test_utils import (
+    create_kv_cache,
+    copy_gradients,
+)
+from keys_values.model import GPT
+from keys_values.utils import randint_torch
+
+
+def args_async_cpu_transfer():
+    return [
+        (cache_name, cachecp_qname)
+        for cache_name, cachecp_qname in product(
+            ["lastrec", "h2o"],
+            ["default", "torch-quantized8"],
+        )
+    ]
+
+
+@_RunIf(min_cuda_gpus=1)
+@pytest.mark.parametrize("cache_name, cachecp_qname", args_async_cpu_transfer())
+def test_async_cpu_transfer_gradients(cache_name, cachecp_qname):
+    """
+    Compares losses and gradients between `async_cpu_transfer=False`
+    (single-stream, the default) and `async_cpu_transfer=True` (CPU-GPU
+    transfers on separate CUDA streams, in parallel with GPU computation).
+    Both must give the same results.
+
+    We run two batches per setting, since some races only corrupt state
+    for subsequent batches.
+    """
+    seed = 31415927
+    torch.random.manual_seed(seed)
+    device = torch.device("cuda", 0)
+
+    dtype = torch.float32
+    torch.set_default_dtype(dtype)
+
+    cache_length = 128
+    num_batches = 2
+    batch_size = 4
+    n_layer = 2
+    n_head = 8
+    n_query_groups = 4
+    head_size = 64
+    vocab_size = 48
+    layers_per_cell = 1
+    chunk_size = 32
+    max_sequence_length = cache_length * 6
+    min_sequence_length = cache_length * 4
+
+    # Create model and KV caches
+    config = Config(
+        n_layer=n_layer,
+        n_head=n_head,
+        n_query_groups=n_query_groups,
+        n_embd=n_head * head_size,
+        block_size=max_sequence_length,
+        vocab_size=vocab_size,
+        rotary_percentage=1,
+    )
+    params = KVCacheParams.from_config(
+        config=config,
+        max_batch_size=batch_size,
+        cache_length=cache_length,
+        dtype=dtype,
+    )
+    mha_kwargs = dict(flexatt_args=FlexAttentionArgs(q_lens=[8, 32, 96, 128]))
+    cache_kwargs = dict(mha_kwargs)
+    if cache_name == "h2o":
+        cache_kwargs["replay_log_blocksize"] = 64
+    with torch.device(device):
+        gpt_model = GPT(config, **mha_kwargs)
+        gpt_model.apply(gpt_model._init_weights)  # Initialization
+    gpt_model.assign_kv_caches(
+        [
+            create_kv_cache(
+                name=cache_name + "-default",
+                params=replace(params, cache_length=cache_length),
+                block_idx=block_idx,
+                **cache_kwargs,
+            )
+            for block_idx in range(n_layer)
+        ]
+    )
+    autograd_hooks_kwargs = dict(
+        max_match_trials_pack_arg=4,
+        may_match_twice=may_match_twice_flex_attention_sdpa,
+    )
+
+    # Create data batches. Sequences are long enough (>= 4 * cache_length)
+    # for rows to have several cells, so that prefetching (CPU -> GPU) and
+    # delayed writes (GPU -> CPU) are really exercised.
+    all_input_ids = []
+    all_targets = []
+    for _ in range(num_batches):
+        seq_length = randint_torch(min_sequence_length, max_sequence_length)
+        token_ids = torch.randint(
+            low=0,
+            high=config.vocab_size,
+            size=(batch_size, seq_length),
+            device=device,
+        )
+        num_output_tokens = randint_torch(4, int(seq_length * 0.75))
+        all_input_ids.append(token_ids[:, :-1])
+        all_targets.append(token_ids[:, (-num_output_tokens):])
+    head_model = HeadModelFactory.create(
+        name=CrossEntropyOnLogits.NAME, config=config
+    )
+
+    # Main loop: First with async_cpu_transfer=False (single stream), then
+    # with async_cpu_transfer=True (multiple streams)
+    gradients = []
+    train_loss_values = []
+    for async_cpu_transfer in [False, True]:
+        if not async_cpu_transfer:
+            print("\n*** Gradient computation with async_cpu_transfer=False ***")
+        else:
+            print("\n*** Gradient computation with async_cpu_transfer=True ***")
+        model = LongContextGradientModel(
+            gpt_model=gpt_model,
+            head_model=head_model,
+            layers_per_cell=layers_per_cell,
+            chunk_size=chunk_size,
+            layercp_qname="default",
+            cachecp_qname=cachecp_qname,
+            autograd_hooks_kwargs=autograd_hooks_kwargs,
+            async_cpu_transfer=async_cpu_transfer,
+            layercp_pin_memory=True,
+            cachecp_pin_memory=True,
+        )
+        model.zero_grad()
+        model.train()
+        loss_values = []
+        for input_ids, targets in zip(all_input_ids, all_targets):
+            loss = model(input_ids, targets)
+            loss.backward()
+            loss_values.append(loss.detach())
+        gradients.append(copy_gradients(gpt_model, device=torch.device("cpu")))
+        train_loss_values.append(loss_values)
+
+    # Compare the two
+    print("\nComparing loss values per batch")
+    for loss, loss_comp in zip(*train_loss_values):
+        torch.testing.assert_close(loss, loss_comp)
+    kwargs = {"atol": 2e-5, "rtol": 4e-5}
+    for name, value in gradients[0].items():
+        value_comp = gradients[1].get(name)
+        if value_comp is None:
+            raise IndexError(
+                f"name = {name} is in gradients[0], but not in gradients[1]"
+            )
+        print(f"Comparing gradient for {name}")
+        assert not torch.isnan(value_comp).any(), f"NaNs in gradient for {name}"
+        torch.testing.assert_close(value, value_comp, **kwargs)
+
+
+@_RunIf(min_cuda_gpus=1)
+def test_async_cpu_transfer_requires_pinned_memory():
+    """
+    `async_cpu_transfer=True` requires pinned CPU memory for both layer
+    input and KV cache checkpoints.
+    """
+    config = Config(
+        n_layer=2,
+        n_head=8,
+        n_query_groups=4,
+        n_embd=8 * 64,
+        block_size=256,
+        vocab_size=48,
+        rotary_percentage=1,
+    )
+    device = torch.device("cuda", 0)
+    with torch.device(device):
+        gpt_model = GPT(config)
+    params = KVCacheParams.from_config(
+        config=config,
+        max_batch_size=2,
+        cache_length=64,
+        dtype=torch.float32,
+    )
+    gpt_model.assign_kv_caches(
+        [
+            create_kv_cache(name="lastrec-default", params=params, block_idx=i)
+            for i in range(config.n_layer)
+        ]
+    )
+    head_model = HeadModelFactory.create(
+        name=CrossEntropyOnLogits.NAME, config=config
+    )
+    for layercp_pin, cachecp_pin in [(False, True), (True, False), (False, False)]:
+        with pytest.raises(ValueError, match="async_cpu_transfer"):
+            LongContextGradientModel(
+                gpt_model=gpt_model,
+                head_model=head_model,
+                layers_per_cell=1,
+                async_cpu_transfer=True,
+                layercp_pin_memory=layercp_pin,
+                cachecp_pin_memory=cachecp_pin,
+            )


### PR DESCRIPTION
Adds opt-in async CPU↔GPU transfer during gradient computation (#62), behind
`--grad.async_cpu_transfer` (default `False`; requires pinned checkpoint
memory). Layer-input checkpoints, KV-cache checkpoints, and head gradients are
moved on dedicated `host_to_device` / `device_to_host` CUDA streams that
overlap main-stream compute, via double buffering in `GradientAccumulator.run`.
Ordering in the cell loop uses GPU-side events, so the host thread isn't blocked.

Re-implements the `cpu_gpu2` design on current `main` and fixes the races that
made that branch produce NaN weights.

## Race fixes vs `cpu_gpu2`

- The d2h checkpoint copy now waits on a main-stream event recorded *after* its
  source is produced (on `cpu_gpu2`, layer L+1's input could be copied before
  the `torch.cat` that computes it — the main NaN source).
- One `torch.cuda.synchronize()` at backward start makes forward checkpoint
  writes host-visible before backward reads them.
- Explicit cross-stream events at the start of `run`, replacing reliance on the
  per-row synchronize.

Also skips that per-row `torch.cuda.synchronize()` (host-blocking ~1 s/row) in
the async path, where events already order things. `async_cpu_transfer=False`
leaves all paths unchanged.

## Testing

- New `test/kvcache/test_gradient_async.py`: compares losses/gradients with the
  flag off vs on over two batches, across cache policy × checkpoint
  quantization. 5/5 pass; existing gradient suites green.
- Full-scale Qwen3-4B LoRA (the config that NaN'd on `cpu_gpu2`): 3 clean steps,
  no NaNs, losses matching the async-off control; ~4–8% faster/iter.
Closes #<62>.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
