### PR TITLE
fix: align the evaluation metrics with baseline method

### DIFF
--- a/keys_values/evaluation/metrics.py
+++ b/keys_values/evaluation/metrics.py
@@ -93,8 +93,8 @@ def sub_exact_match(
         Is there a sub exact match?
 
     """
-    response = normalize_string_response(response)
-    target_value = str(target_value)
+    response = normalize_string_response(response).lower()
+    target_value = str(target_value).lower()
     is_match = target_value in response
     if not is_match and threshold is not None:
         match_score = sub_exact_similarity(response, target_value)

--- a/keys_values/evaluation/response_parser.py
+++ b/keys_values/evaluation/response_parser.py
@@ -198,15 +198,6 @@ def extract_choice_letter(
         if cue_re.search(window):
             score += 10
 
-        # Extra bonus if patterns like "answer: X" appear tightly
-        tight = text[max(0, start - 15) : min(len(text), end + 15)]
-        if re.search(
-            r"(answer|correct)\s*[:\-]?\s*$",
-            tight[: (start - max(0, start - 15))],
-            re.IGNORECASE,
-        ):
-            score += 5
-
         candidates.append((score, start, ch))
 
     if not candidates:


### PR DESCRIPTION
## Metric Alignment Fix

In this fix, we did two changes to make it aligned with the baseline evaluation:
- For RAG task evaluation, do the lower case for both the target and response
- For ICL task evaluation, remove the redundant block to assign extra bonus to a specific response format


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
