### PR TITLE
Fix #140: factory default init_grace_tokens for lastrec (attention sinks)

### DIFF
--- a/keys_values/kvcache/factory.py
+++ b/keys_values/kvcache/factory.py
@@ -65,6 +65,43 @@ SUPPORTED_CACHES = {
     if do_def or quant != "default"
 }
 
+# Safe eviction default for `lastrec`, applied by the factory if the caller
+# does not specify `init_grace_tokens`. `lastrec` evicts the *initial* tokens
+# first; trained LLMs use those tokens (BOS, template header) as attention
+# sinks, and evicting them collapses generation to immediate EOS/garbage
+# (Xiao et al., "Efficient Streaming Language Models with Attention Sinks";
+# see https://github.com/awslabs/keys_values/issues/140). Pinning a few
+# initial tokens restores generation.
+#
+# H2O-type caches are not affected by sink eviction (`keep_initial_fraction`
+# preserves the initial tokens, and their accumulated attention scores keep
+# them resident), so their defaults are left unchanged. For applications
+# where the recently read tail matters (e.g. question-at-the-end prompts
+# under tight budgets), tune `grace_period` and/or `normalize_scores=True`
+# explicitly.
+#
+# Pass an explicit value (e.g. 0) in `cache_kwargs` to override.
+DEFAULT_INIT_GRACE_TOKENS = 16  # lastrec: initial tokens kept indefinitely
+
+
+def _apply_safe_eviction_defaults(
+    name: str,
+    cache_length: int,
+    cache_kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Injects the `lastrec` attention-sink default into `cache_kwargs` (returns
+    a copy), unless the caller specified `init_grace_tokens`. `cache_length`
+    is the smallest cache length being created.
+    """
+    cache_kwargs = dict(cache_kwargs)
+    cname, _ = split_name(name)
+    if cname == "lastrec" and "init_grace_tokens" not in cache_kwargs:
+        cache_kwargs["init_grace_tokens"] = min(
+            DEFAULT_INIT_GRACE_TOKENS, max(cache_length // 8, 1)
+        )
+    return cache_kwargs
+
 
 class KVCacheFactory:
     """
@@ -138,6 +175,7 @@ class KVCacheFactory:
         )
         if cache_kwargs is None:
             cache_kwargs = dict()
+        cache_kwargs = _apply_safe_eviction_defaults(name, cache_length, cache_kwargs)
 
         cache_type = SUPPORTED_CACHES.get(name)
         if cache_type is not None:
@@ -257,6 +295,9 @@ class KVCacheFactory:
             raise ValueError(
                 f"cache_length = {cache_length}, must contain only positive integers"
             )
+        cache_kwargs = _apply_safe_eviction_defaults(
+            name, min(cache_length), cache_kwargs
+        )
 
         cache_type = SUPPORTED_CACHES.get(name)
         if cache_type is not None:
@@ -365,6 +406,7 @@ class KVCacheFactory:
             raise ValueError(
                 f"name = {name}: Offloading does not support default buffers, must be quantized"
             )
+        cache_kwargs = _apply_safe_eviction_defaults(name, cache_length, cache_kwargs)
         cache_type = SUPPORTED_CACHES.get(name)
         if cache_type is not None:
             max_num_ranges = cache_kwargs.get("max_num_ranges")

--- a/keys_values/kvcache/test_utils.py
+++ b/keys_values/kvcache/test_utils.py
@@ -46,6 +46,11 @@ def create_kv_cache(
         n_query_groups=params.n_query_groups,
         n_layer=1,
     )
+    # Unit tests exercise the raw eviction mechanics: switch off the factory's
+    # lastrec attention-sink default unless the test asks for it explicitly.
+    cname = name.split("-torch")[0].split("-bnb")[0].split("-default")[0]
+    if cname == "lastrec":
+        kwargs.setdefault("init_grace_tokens", 0)
     return KVCacheFactory.create_single(
         name=name,
         config=config,


### PR DESCRIPTION
Split out of #142 per review, and trimmed to the conservative scope discussed there: **only `lastrec` gets a factory default** (`init_grace_tokens = min(16, cache_length // 8)`); the H2O family is unchanged.

## Why

`lastrec` evicts the *initial* tokens first. Trained LLMs use those tokens (BOS, template header) as attention sinks, and evicting them collapses generation to immediate EOS/garbage — every evicting configuration scored 0.000 on HELMET before this fix (measured data in #140). Pinning a few initial tokens restores generation. H2O-type caches are not affected: `keep_initial_fraction` plus accumulated attention scores already keep the sink tokens resident.

## Scope

- `keys_values/kvcache/factory.py`: `_apply_safe_eviction_defaults` applied in the three factory entry points; callers can pass an explicit value (e.g. `0`) to override.
- `keys_values/kvcache/test_utils.py`: unit tests exercise raw eviction mechanics, so `create_kv_cache` opts out (`init_grace_tokens=0`) unless a test asks otherwise.

## Testing

`test/kvcache`: 956 passed, 85 skipped.

#142 no longer touches these files and is now RL-only.