### PR TITLE
Fix HELMET loader reproducibility: seed dev/eval split and demo sampling

### DIFF
--- a/keys_values/data/load_helmet_dev_eval.py
+++ b/keys_values/data/load_helmet_dev_eval.py
@@ -483,8 +483,12 @@ def load_rag(
     instance_data = load_dataset("json", data_files=instance_path)["train"]
     demon_data = load_dataset("json", data_files=demo_path)["train"]
 
+    # Seeded RNG: the dev/eval question split must be identical across
+    # machines, otherwise results computed against different split caches
+    # are not comparable (the split is drawn once and cached to disk).
+    split_rng = random.Random(42)
     if dataset_key in ["nq", "trivia_qa", "hotpot_qa"]:
-        eval_questions = random.sample(
+        eval_questions = split_rng.sample(
             sorted(set(instance_data["question"])), eval_questions_num
         )
         eval_data = instance_data.filter(lambda x: x["question"] in eval_questions)
@@ -494,7 +498,7 @@ def load_rag(
         popularity_filtered = instance_data.filter(
             lambda x: math.log10(x["s_pop"]) < popularity_threshold
         )
-        eval_questions = random.sample(
+        eval_questions = split_rng.sample(
             sorted(set(popularity_filtered["id"])), eval_questions_num
         )
         eval_data = popularity_filtered.filter(lambda x: x["id"] in eval_questions)
@@ -626,6 +630,16 @@ def load_cited_generation(
                 for idx, d in enumerate(instance["docs"][:num_docs])
             ]
         )
+        # Deterministic per-instance demo choice (mirrors the hash-seeded
+        # demo shuffle in the RAG loader): unseeded sampling here made the
+        # constructed prompts differ between machines / cache rebuilds.
+        h = (
+            int(
+                hashlib.sha256(str(instance["question"]).encode("utf-8")).hexdigest(),
+                16,
+            )
+            % 2**31
+        )
         demos = "\n\n\n".join(
             [
                 demo_template.format(
@@ -637,7 +651,7 @@ def load_cited_generation(
                         ]
                     ),
                 )
-                for demo in random.sample(demo_data["demos"], shots)
+                for demo in random.Random(h).sample(demo_data["demos"], shots)
             ]
         )
         return {


### PR DESCRIPTION
Two unseeded random sites in `load_helmet_dev_eval.py` made the constructed benchmark differ between machines and cache rebuilds, so absolute results were not comparable across hosts. Found while replicating the #142 evals on a fresh instance: base-model dense-eval EM came out 0.11 vs the 0.33 measured on the original box — same code, same model, different (unseeded) eval split and few-shot demos.

- `load_rag`: the 100 eval questions were drawn with bare `random.sample`; now `random.Random(42)`, consistent with `seed = 42` used elsewhere in the module. The split is drawn once and cached to disk, so any two hosts now build identical dev/eval splits.
- `load_citations`: per-instance demo choice used unseeded `random.sample` inside a `.map`; now hash-seeded per question, mirroring the existing RAG-loader pattern (`demos.shuffle(seed=h)`).

Note: `longtrain/` split caches built before this fix retain their old draw; delete the cache directory to rebuild deterministically. Results measured against pre-fix caches (including the numbers posted on #142) are internally consistent but not comparable across machines — re-baselining under the seeded split is in progress.

Testing: `test/data` passes (9 passed). Related: #142 gains a driver-side fix (question-diverse eval record selection) in the same spirit.