### PR TITLE
Fix #148: walk annotation chain when final buffer is 2+ chunks ahead

### DIFF
--- a/keys_values/kvcache/gradient/autograd_hooks.py
+++ b/keys_values/kvcache/gradient/autograd_hooks.py
@@ -150,6 +150,20 @@ class PackArgumentAsAnnotation:
 
 
 @dataclass(frozen=True)
+class ParkedBufferState:
+    """
+    Buffer state reconstructed ahead of its unpack request (chain walk, see
+    :meth:`CellComputationAutogradHooks._unpack_from_annotation`). Parked on
+    CPU: parking happens during backward, when device memory is tightest,
+    and a full-size device clone per walked chunk can push a large
+    configuration into OOM.
+    """
+
+    x_cpu: torch.Tensor
+    device: torch.device
+
+
+@dataclass(frozen=True)
 class PackArgumentAsIndex:
     index_3d: torch.Tensor
     final_dim: int
@@ -790,6 +804,8 @@ class CellComputationAutogradHooks(AutogradHooks):
             if idd in self._id_to_unpacked:
                 # Unpacked this one before: Just return it
                 x = self._id_to_unpacked[idd]
+                if isinstance(x, ParkedBufferState):
+                    x = x.x_cpu.to(device=x.device)
                 self._id_counts[idd] -= 1
                 if self._id_counts[idd] == 0:
                     # Not needed anymore:
@@ -931,15 +947,26 @@ class CellComputationAutogradHooks(AutogradHooks):
                         # `annot` was applied earlier than autograd asks for
                         # it. Park the state just reconstructed (as a copy,
                         # since `buffer` is modified in place by subsequent
-                        # steps), so :meth:`unpack_hook` can serve the ID later
-                        parked = buffer.clone()
-                        if park_dtype is not None and parked.dtype != park_dtype:
-                            parked = parked.to(dtype=park_dtype)
+                        # steps), so :meth:`unpack_hook` can serve the ID
+                        # later. Device buffers are parked on CPU to avoid
+                        # OOM during backward.
+                        target_dtype = (
+                            park_dtype if park_dtype is not None else buffer.dtype
+                        )
+                        if buffer.device.type == "cpu":
+                            parked = buffer.detach().clone().to(dtype=target_dtype)
+                        else:
+                            parked = ParkedBufferState(
+                                x_cpu=buffer.detach().to(
+                                    device="cpu", dtype=target_dtype
+                                ),
+                                device=buffer.device,
+                            )
                         self._id_to_unpacked[park_id] = parked
                         if park_id not in self._id_counts:
                             self._id_counts[park_id] = 1
                         if self._debug_test_args:
-                            self._debug_log_args.append((parked.clone(), annot))
+                            self._debug_log_args.append((buffer.clone(), annot))
                 # Sanity check
                 assert (
                     annot.shape == buffer.shape

--- a/keys_values/kvcache/gradient/autograd_hooks.py
+++ b/keys_values/kvcache/gradient/autograd_hooks.py
@@ -520,6 +520,7 @@ class CellComputationAutogradHooks(AutogradHooks):
         self._packed_arg_for_id = None
         self._id_counts = None
         self._id_to_unpacked = None
+        self._orphan_annotation_ids = None
         # ID assigned to next pack hook argument
         self._next_id = None
         self._num_matched_annotations = None
@@ -590,6 +591,10 @@ class CellComputationAutogradHooks(AutogradHooks):
         self._packed_arg_for_id: Dict[int, PackedArgumentType] = dict()
         self._id_counts: Dict[int, int] = dict()
         self._id_to_unpacked: Dict[int, torch.Tensor] = dict()
+        # IDs inserted by :meth:`_flush_remaining_pack_arguments` to keep the
+        # annotation chain complete. Nothing in the autograd graph refers to
+        # them, so states reconstructed for them need not be parked.
+        self._orphan_annotation_ids: Set[int] = set()
         self._next_id = 0
         self._num_matched_annotations = 0
         self._num_comparisons = 0
@@ -625,6 +630,8 @@ class CellComputationAutogradHooks(AutogradHooks):
             self._packed_arg_for_id = None
         self._id_counts = None
         self._id_to_unpacked = None
+        if self._orphan_annotation_ids is not None:
+            self._orphan_annotation_ids.clear()
         self._next_id = None
         self._num_matched_annotations = None
         self._num_comparisons = None
@@ -882,17 +889,18 @@ class CellComputationAutogradHooks(AutogradHooks):
                     idd, prior_annotation = found
                     if self.debug_print_annotations:
                         print(f"--> Doing {str(prior_annotation)} first")
-                    if prior_chunk_idx > chunk_idx:
-                        # Applied early: Remove the entry here, park the
-                        # reconstructed state below
-                        value = self._packed_arg_for_id.pop(idd)
-                        chain.append((prior_annotation, idd, value.target_dtype))
-                    else:
-                        # `prior_chunk_idx == chunk_idx` ("ext-*" case): The
-                        # entry stays in `_packed_arg_for_id`. If its ID is
-                        # unpacked later, the "already done" branch above
-                        # serves it
+                    # The entry is applied early, so it is removed here. We
+                    # park the state it reconstructs (below), unless nothing
+                    # in the autograd graph can ask for this ID: orphan IDs
+                    # are inserted by
+                    # :meth:`_flush_remaining_pack_arguments` purely to keep
+                    # the chain complete, and parking those would retain
+                    # full-size buffers that are never fetched.
+                    value = self._packed_arg_for_id.pop(idd)
+                    if idd in self._orphan_annotation_ids:
                         chain.append((prior_annotation, None, None))
+                    else:
+                        chain.append((prior_annotation, idd, value.target_dtype))
                 annotations_todo = chain + annotations_todo
             for annot, park_id, park_dtype in annotations_todo:
                 if annot.is_ext:
@@ -1286,6 +1294,7 @@ class CellComputationAutogradHooks(AutogradHooks):
                                 target_dtype=None,
                             )
                         )
+                        self._orphan_annotation_ids.add(self._next_id)
                         self._next_id += 1
         self._node_annotations.nodes.clear()
         # Flush all remaining pack arguments (these will not be packed)

--- a/keys_values/kvcache/gradient/autograd_hooks.py
+++ b/keys_values/kvcache/gradient/autograd_hooks.py
@@ -432,6 +432,16 @@ class CellComputationAutogradHooks(AutogradHooks):
     "scatter-key" annotation, which can then be done earlier (and skipped
     later).
 
+    More generally, the backward traversal may request an annotation whose
+    buffer state is more than one chunk behind the current final buffer. This
+    happens if autograd's backward for the intermediate chunks is served
+    without unpacking their "scatter-*" / "cat-*" annotations, e.g., when a
+    generated region spans three or more chunks (issue #148). In this case,
+    :meth:`_unpack_from_annotation` walks the annotation chain, applying
+    intermediate annotations early. Reconstructed intermediate states are
+    parked in `_id_to_unpacked`, so their IDs can still be served if autograd
+    asks for them later.
+
     Packing broadcast-extended indexes:
 
     A broadcast-extended index is a 4D tensor of integer dtype, obtained as
@@ -826,33 +836,65 @@ class CellComputationAutogradHooks(AutogradHooks):
                 print(
                     f"_unpack_from_annotation: {str(annotation)}, buffer={buffer.shape}, final_idx={final_idx}"
                 )
-            # This is complex, because it happens that "ext-*" appears before
-            # "scatter-*" or "cat-*" for the same node. In this case, we need
-            # to first execute this "prior annotation", since otherwise the
-            # input to "ext-*" does not exist.
-            annotations_todo = [annotation]
-            if annotation.is_ext:
-                if final_idx == chunk_idx + 1:
-                    # ext-* annotation comes too early, need to do another one first
-                    prior_annotation = self._find_prior_annotation(annotation)
+            # This is complex, for two reasons:
+            # (1) It happens that "ext-*" appears before "scatter-*" or
+            #     "cat-*" for the same node. In this case, we need to first
+            #     execute this "prior annotation", since otherwise the input
+            #     to "ext-*" does not exist.
+            # (2) The final buffer can be more than one chunk ahead of
+            #     `annotation`. This happens when autograd's backward for the
+            #     intermediate chunks is served without unpacking their
+            #     "scatter-*" / "cat-*" annotations (observed with generated
+            #     regions spanning 3+ chunks, see issue #148). All "scatter" /
+            #     "cat" annotations are kept in `_packed_arg_for_id` (see
+            #     :meth:`_flush_remaining_pack_arguments`), so we can walk the
+            #     chain here, applying intermediate annotations early. Their
+            #     reconstructed states are parked in `_id_to_unpacked`, in
+            #     case autograd asks for their IDs later on.
+            # `first_needed` is the buffer state (chunk index) required
+            # before `annotation` itself can be applied:
+            first_needed = chunk_idx if annotation.is_ext else chunk_idx + 1
+            # Entries are `(annot, park_id, park_dtype)`. If `park_id` is
+            # given, the state reconstructed by `annot` is parked under this
+            # ID (see (2) above)
+            annotations_todo = [(annotation, None, None)]
+            if final_idx < chunk_idx:
+                raise ValueError(
+                    f"Annotation {str(annotation)}: final chunk_idx = {final_idx}, must be >= {chunk_idx}"
+                )
+            elif not annotation.is_ext and final_idx == chunk_idx:
+                # Has already been done to support ext-* annotation
+                if self.debug_print_annotations:
+                    print("--> Skip (already done)")
+                annotations_todo = []
+            elif final_idx > first_needed:
+                # Walk the annotation chain from `final_idx - 1` down to
+                # `first_needed`, so that `annotation` can be applied last
+                chain = []
+                for prior_chunk_idx in range(final_idx - 1, first_needed - 1, -1):
+                    found = self._find_chain_annotation(annotation, prior_chunk_idx)
+                    if found is None:
+                        raise ValueError(
+                            f"Annotation {str(annotation)}: final chunk_idx = "
+                            f"{final_idx}: Cannot reconstruct, missing "
+                            f"'scatter'/'cat' annotation for chunk {prior_chunk_idx}"
+                        )
+                    idd, prior_annotation = found
                     if self.debug_print_annotations:
                         print(f"--> Doing {str(prior_annotation)} first")
-                    annotations_todo.insert(0, prior_annotation)
-                elif final_idx != chunk_idx:
-                    raise ValueError(
-                        f"Annotation {str(annotation)}: final chunk_idx = {final_idx}, must be in [{chunk_idx}, {chunk_idx + 1}]"
-                    )
-            else:
-                if final_idx == chunk_idx:
-                    # Has already been done to support ext-* annotation
-                    if self.debug_print_annotations:
-                        print("--> Skip (already done)")
-                    annotations_todo = []
-                elif final_idx != chunk_idx + 1:
-                    raise ValueError(
-                        f"Annotation {str(annotation)}: final chunk_idx = {final_idx}, must be in [{chunk_idx}, {chunk_idx + 1}]"
-                    )
-            for annot in annotations_todo:
+                    if prior_chunk_idx > chunk_idx:
+                        # Applied early: Remove the entry here, park the
+                        # reconstructed state below
+                        value = self._packed_arg_for_id.pop(idd)
+                        chain.append((prior_annotation, idd, value.target_dtype))
+                    else:
+                        # `prior_chunk_idx == chunk_idx` ("ext-*" case): The
+                        # entry stays in `_packed_arg_for_id`. If its ID is
+                        # unpacked later, the "already done" branch above
+                        # serves it
+                        chain.append((prior_annotation, None, None))
+                annotations_todo = chain + annotations_todo
+            for annot, park_id, park_dtype in annotations_todo:
                 if annot.is_ext:
                     # `target_dim1` is either `n_head` or `n_query_groups`,
                     # depending on whether the annotation includes extension
@@ -874,9 +916,22 @@ class CellComputationAutogradHooks(AutogradHooks):
                     self._node_annotations.set_final(
                         buffer,
                         layer_idx,
-                        chunk_idx,
+                        annot.chunk_idx,
                         kind,
                     )
+                    if park_id is not None:
+                        # `annot` was applied earlier than autograd asks for
+                        # it. Park the state just reconstructed (as a copy,
+                        # since `buffer` is modified in place by subsequent
+                        # steps), so :meth:`unpack_hook` can serve the ID later
+                        parked = buffer.clone()
+                        if park_dtype is not None and parked.dtype != park_dtype:
+                            parked = parked.to(dtype=park_dtype)
+                        self._id_to_unpacked[park_id] = parked
+                        if park_id not in self._id_counts:
+                            self._id_counts[park_id] = 1
+                        if self._debug_test_args:
+                            self._debug_log_args.append((parked.clone(), annot))
                 # Sanity check
                 assert (
                     annot.shape == buffer.shape
@@ -892,15 +947,30 @@ class CellComputationAutogradHooks(AutogradHooks):
     def _get_cache_length(self, layer_idx: int) -> int:
         return self.cache_lengths[layer_idx - self.first_layer_idx]
 
-    def _find_prior_annotation(self, annotation: NodeAnnotation) -> NodeAnnotation:
-        assert annotation.is_ext
+    def _find_chain_annotation(
+        self,
+        annotation: NodeAnnotation,
+        chunk_idx: int,
+    ) -> Optional[Tuple[int, NodeAnnotation]]:
+        """
+        Searches `_packed_arg_for_id` for the "scatter-*" or "cat-*"
+        annotation on the same chain as `annotation` (i.e., same layer and
+        keys/values kind), but with chunk index `chunk_idx`.
+
+        Args:
+            annotation: Annotation determining the chain
+            chunk_idx: Chunk index to search for
+
+        Returns:
+            `(id, chain_annotation)` if found, otherwise `None`
+
+        """
         layer_idx = annotation.layer_idx
-        chunk_idx = annotation.chunk_idx
         is_keys = annotation.is_keys
-        result = next(
+        return next(
             (
-                e.annot
-                for e in self._packed_arg_for_id.values()
+                (idd, e.annot)
+                for idd, e in self._packed_arg_for_id.items()
                 if (
                     isinstance(e, PackArgumentAsAnnotation)
                     and e.annot.is_keys == is_keys
@@ -911,11 +981,6 @@ class CellComputationAutogradHooks(AutogradHooks):
             ),
             None,
         )
-        if result is None:
-            raise IndexError(
-                f"{str(annotation)}: Don't find prior annotation for this one!"
-            )
-        return result
 
     @staticmethod
     def _unpack_scatter(

--- a/keys_values/kvcache/gradient/autograd_hooks.py
+++ b/keys_values/kvcache/gradient/autograd_hooks.py
@@ -203,6 +203,12 @@ class AnnotationUsageLog:
     unmatched_pack_args: List[UnmatchedPackHookArgument] = field(default_factory=list)
     unmatched_annotations: List[NodeAnnotationForLog] = field(default_factory=list)
     track_unmatched_annotations_for_pack_args: bool = False
+    # Peak memory retained (CPU) by parked buffer states within this cell,
+    # and the peak number of simultaneously parked states. Bounded by
+    # (num_chunks_per_cell - 1) * 2 * eff_num_layers buffers; typically far
+    # smaller, since states are freed as soon as their ID is fetched
+    parked_peak_bytes: int = 0
+    parked_peak_count: int = 0
 
     def report(self) -> str:
         lines: List[str] = [
@@ -211,6 +217,8 @@ class AnnotationUsageLog:
             f"Number of delta comparisons:             {self.num_comparisons}",
             f"Number of 4D indexes packed:             {self.num_4d_indexes}",
             f"Number of unmatched scatter annotations: {self.num_unmatched_scatter_cat}",
+            f"Parked states, peak (CPU):               {self.parked_peak_count} "
+            f"({self.parked_peak_bytes / (1 << 20):.1f} MiB)",
         ]
         if self.unmatched_annotations:
             lines.append("Remaining unmatched annotations:")
@@ -535,6 +543,10 @@ class CellComputationAutogradHooks(AutogradHooks):
         self._id_counts = None
         self._id_to_unpacked = None
         self._orphan_annotation_ids = None
+        self._parked_bytes_for_id = None
+        self._parked_bytes = 0
+        self._parked_peak_bytes = 0
+        self._parked_peak_count = 0
         # ID assigned to next pack hook argument
         self._next_id = None
         self._num_matched_annotations = None
@@ -605,6 +617,12 @@ class CellComputationAutogradHooks(AutogradHooks):
         self._packed_arg_for_id: Dict[int, PackedArgumentType] = dict()
         self._id_counts: Dict[int, int] = dict()
         self._id_to_unpacked: Dict[int, torch.Tensor] = dict()
+        # Memory accounting for parked buffer states: ID -> bytes retained.
+        # Peaks are reported in :meth:`annotation_usage_log`
+        self._parked_bytes_for_id: Dict[int, int] = dict()
+        self._parked_bytes = 0
+        self._parked_peak_bytes = 0
+        self._parked_peak_count = 0
         # IDs inserted by :meth:`_flush_remaining_pack_arguments` to keep the
         # annotation chain complete. Nothing in the autograd graph refers to
         # them, so states reconstructed for them need not be parked.
@@ -646,6 +664,9 @@ class CellComputationAutogradHooks(AutogradHooks):
         self._id_to_unpacked = None
         if self._orphan_annotation_ids is not None:
             self._orphan_annotation_ids.clear()
+        if self._parked_bytes_for_id is not None:
+            self._parked_bytes_for_id.clear()
+        self._parked_bytes = 0
         self._next_id = None
         self._num_matched_annotations = None
         self._num_comparisons = None
@@ -748,6 +769,8 @@ class CellComputationAutogradHooks(AutogradHooks):
             unmatched_pack_args=self._unmatched_pack_args.copy(),
             unmatched_annotations=remaining_annotations,
             track_unmatched_annotations_for_pack_args=self._track_unmatched_annotations,
+            parked_peak_bytes=self._parked_peak_bytes,
+            parked_peak_count=self._parked_peak_count,
         )
 
     def debug_log_args(self) -> Optional[List[Tuple[torch.Tensor, NodeAnnotation]]]:
@@ -810,6 +833,8 @@ class CellComputationAutogradHooks(AutogradHooks):
                 if self._id_counts[idd] == 0:
                     # Not needed anymore:
                     del self._id_to_unpacked[idd]
+                    parked_bytes = self._parked_bytes_for_id.pop(idd, 0)
+                    self._parked_bytes -= parked_bytes
             else:
                 value = self._packed_arg_for_id.pop(idd)
                 if isinstance(value, PackArgumentAsAnnotation):
@@ -965,6 +990,23 @@ class CellComputationAutogradHooks(AutogradHooks):
                         self._id_to_unpacked[park_id] = parked
                         if park_id not in self._id_counts:
                             self._id_counts[park_id] = 1
+                        # Memory accounting (reported in the usage log)
+                        parked_tensor = (
+                            parked.x_cpu
+                            if isinstance(parked, ParkedBufferState)
+                            else parked
+                        )
+                        num_bytes = (
+                            parked_tensor.numel() * parked_tensor.element_size()
+                        )
+                        self._parked_bytes_for_id[park_id] = num_bytes
+                        self._parked_bytes += num_bytes
+                        self._parked_peak_bytes = max(
+                            self._parked_peak_bytes, self._parked_bytes
+                        )
+                        self._parked_peak_count = max(
+                            self._parked_peak_count, len(self._parked_bytes_for_id)
+                        )
                         if self._debug_test_args:
                             self._debug_log_args.append((buffer.clone(), annot))
                 # Sanity check

--- a/keys_values/rl/grpo/loop.py
+++ b/keys_values/rl/grpo/loop.py
@@ -37,6 +37,7 @@ from typing import Callable, Dict
 
 import torch
 
+from keys_values.finetune.utils import may_match_twice_flex_attention_sdpa
 from keys_values.rl.grpo.loss import GRPOLossHeadModel
 from keys_values.rl.grpo.rollout import generate_completions
 from keys_values.kvcache.gradient.main import LongContextGradientModel
@@ -198,6 +199,14 @@ def grpo_step(
         layers_per_cell=layers_per_cell,
         chunk_size=chunk_size,
         verbose=verbose,
+        # With the new training replay cache, "ext-*" annotations match twice;
+        # without `may_match_twice`, the second save is left as an unmatched
+        # pack argument, which can stall the annotation chain in the chunked
+        # backward (issue #148). This mirrors the finetune path
+        # (`may_match_twice_factory`).
+        autograd_hooks_kwargs=dict(
+            may_match_twice=may_match_twice_flex_attention_sdpa,
+        ),
     )
     grad_model.train()
     optimizer.zero_grad(set_to_none=True)

--- a/test/kvcache/test_autograd_hooks.py
+++ b/test/kvcache/test_autograd_hooks.py
@@ -16,9 +16,11 @@ from itertools import product
 import torch
 import pytest
 
-from keys_values.kvcache.base import KVCacheParams
+from keys_values.config import Config
+from keys_values.kvcache.base import DefaultKVCacheReplayLog, KVCacheParams
 from keys_values.kvcache.gradient.autograd_hooks import (
     CellComputationAutogradHooks,
+    PackArgumentAsAnnotation,
 )
 from keys_values.kvcache.gradient.annotation import (
     NodeAnnotation,
@@ -160,3 +162,143 @@ def test_extract_delta(device, dtype):
             annotation=annotation,
         )
         torch.testing.assert_close(delta, parg_delta)
+
+
+@pytest.mark.parametrize(
+    "device, num_states",
+    product(available_backends(), [2, 3, 5]),
+)
+def test_unpack_walks_multi_chunk_annotation_chain(device, num_states):
+    """
+    Regression test for issue #148: `_unpack_from_annotation` used to require
+    the final buffer to be at most one chunk ahead of the annotation being
+    unpacked. With long generated regions spanning 3+ chunks, autograd's
+    backward can be served for intermediate chunks without unpacking their
+    "scatter-*" annotations, so the gap can grow beyond one chunk, and the
+    backward failed with `ValueError: ... final chunk_idx = 3, must be in
+    [1, 2]`.
+
+    We build a chain of ground-truth buffer states `1, ..., num_states`,
+    linked by "scatter-value" annotations (the annotation with
+    `chunk_idx == c` reconstructs state `c` from state `c + 1`), set the
+    final buffer to state `num_states`, and then unpack the annotation for
+    chunk 1 directly (gap of `num_states - 1` chunks). The unpack must walk
+    the chain, and the intermediate states (applied early) must still be
+    served when their IDs are unpacked later.
+
+    """
+    seed = 31415927
+    torch.random.manual_seed(seed)
+    dtype = torch.float32
+
+    batch_size = 2
+    n_head = 4
+    n_query_groups = 2
+    head_size = 8
+    cache_length = 32
+    chunk_size = 8
+    layer_idx = 0
+    kind = "scatter-value"
+
+    config = Config(
+        n_layer=1,
+        n_head=n_head,
+        n_query_groups=n_query_groups,
+        n_embd=n_head * head_size,
+        block_size=cache_length + num_states * chunk_size,
+        vocab_size=48,
+        rotary_percentage=1,
+    )
+    params = KVCacheParams(
+        max_batch_size=batch_size,
+        n_query_groups=n_query_groups,
+        cache_length=cache_length,
+        head_size=head_size,
+        n_head=n_head,
+        dtype=dtype,
+    )
+    hooks = CellComputationAutogradHooks(
+        config=config,
+        batch_size=batch_size,
+    )
+    token_kwargs = dict(dtype=torch.int64, device=device)
+    replay_log = DefaultKVCacheReplayLog(
+        token_chunks=[torch.zeros(batch_size, cache_length, **token_kwargs)]
+        + [
+            torch.zeros(batch_size, chunk_size, **token_kwargs)
+            for _ in range(num_states)
+        ],
+        cache_length=cache_length,
+        max_prefill_length=cache_length,
+        grace_period=0,
+    )
+    hooks.initialize_cell(
+        eff_num_layers=1,
+        num_chunks=num_states + 1,
+        first_layer_idx=layer_idx,
+        first_chunk_idx=0,
+        cache_lengths=[cache_length],
+        replay_logs=[replay_log],
+    )
+
+    # Ground-truth buffer states 1, ..., num_states. State `c + 1` arises
+    # from state `c` by scattering new values at duplicate-free indexes; the
+    # annotation with `chunk_idx == c` stores this index and the overwritten
+    # old values (`delta`), as in
+    # `TrainingAttnWeightsReplayCache._create_node_before_creator`
+    buffer_kwargs = dict(dtype=dtype, device=device)
+    states = {
+        1: torch.randn(
+            batch_size, n_query_groups, cache_length, head_size, **buffer_kwargs
+        )
+    }
+    for c in range(2, num_states + 1):
+        prev = states[c - 1]
+        index = expand_index(
+            random_index(params, 0, cache_length, num=chunk_size, device=device),
+            head_size,
+        )
+        hooks.node_annotations.append_safe(
+            NodeAnnotation(
+                kind=kind,
+                layer_idx=layer_idx,
+                chunk_idx=c - 1,
+                shape=tuple(prev.shape),
+                index=index,
+                delta=prev.gather(2, index),
+            )
+        )
+        new_values = torch.randn(
+            batch_size, n_query_groups, chunk_size, head_size, **buffer_kwargs
+        )
+        states[c] = prev.scatter(2, index, new_values)
+    hooks.node_annotations.set_final(
+        x=states[num_states],
+        layer_idx=layer_idx,
+        chunk_idx=num_states,
+        kind=kind,
+    )
+    # Simulate the forward/backward boundary: unmatched "scatter" annotations
+    # are entered into `_packed_arg_for_id` under fresh IDs
+    hooks._match_annotations(flush_pack_args=True)
+    ids = {
+        e.annot.chunk_idx: idd
+        for idd, e in hooks._packed_arg_for_id.items()
+        if isinstance(e, PackArgumentAsAnnotation)
+    }
+    assert set(ids.keys()) == set(range(1, num_states))
+
+    # Unpack the annotation for chunk 1 with the final buffer at chunk
+    # `num_states`. Before the fix, this raised ValueError for
+    # `num_states > 2`
+    x1 = hooks.unpack_hook(ids[1])
+    torch.testing.assert_close(x1, states[1])
+    assert hooks.node_annotations.get_final(layer_idx, kind)[1] == 1
+
+    # Intermediate annotations were applied early; their reconstructed
+    # states must still be served when autograd unpacks their IDs
+    for c in range(2, num_states):
+        x_c = hooks.unpack_hook(ids[c])
+        torch.testing.assert_close(x_c, states[c])
+    # All parked states have been consumed
+    assert not hooks._id_to_unpacked

--- a/test/kvcache/test_autograd_hooks.py
+++ b/test/kvcache/test_autograd_hooks.py
@@ -295,10 +295,146 @@ def test_unpack_walks_multi_chunk_annotation_chain(device, num_states):
     torch.testing.assert_close(x1, states[1])
     assert hooks.node_annotations.get_final(layer_idx, kind)[1] == 1
 
-    # Intermediate annotations were applied early; their reconstructed
-    # states must still be served when autograd unpacks their IDs
+    # The intermediate annotations were applied early and consumed. They were
+    # inserted by the flush purely to keep the chain complete (no autograd
+    # node refers to them), so their states are not retained
     for c in range(2, num_states):
-        x_c = hooks.unpack_hook(ids[c])
-        torch.testing.assert_close(x_c, states[c])
-    # All parked states have been consumed
+        assert ids[c] not in hooks._packed_arg_for_id
     assert not hooks._id_to_unpacked
+
+
+@pytest.mark.parametrize("device", available_backends())
+def test_unpack_out_of_order_request_after_walking_past(device):
+    """
+    Second regression test for issue #148. After the chain-walk fix, long
+    32k runs hit the mirror case: the buffer had been walked *past* a chunk,
+    and autograd then asked for that chunk's state, failing with
+    `final chunk_idx = 14, must be >= 15`.
+
+    This happens when an annotation is applied early (to serve an `ext-*`
+    annotation for the same chunk, or as part of a chain walk), the buffer is
+    then walked further down by a later request, and only afterwards does
+    autograd unpack the early-applied annotation's own ID. The state must be
+    parked when it is applied early, so it can still be served.
+
+    Here we unpack chunk 2 first (walking final 3 -> 2), then chunk 1
+    (walking 2 -> 1), then ask for chunk 2 again -- which is only possible if
+    chunk 2's state was retained.
+
+    """
+    seed = 271828
+    torch.random.manual_seed(seed)
+    dtype = torch.float32
+
+    batch_size = 2
+    n_head = 4
+    n_query_groups = 2
+    head_size = 8
+    cache_length = 32
+    chunk_size = 8
+    num_states = 3
+    layer_idx = 0
+    kind = "scatter-value"
+
+    config = Config(
+        n_layer=1,
+        n_head=n_head,
+        n_query_groups=n_query_groups,
+        n_embd=n_head * head_size,
+        block_size=cache_length + num_states * chunk_size,
+        vocab_size=48,
+        rotary_percentage=1,
+    )
+    params = KVCacheParams(
+        max_batch_size=batch_size,
+        n_query_groups=n_query_groups,
+        cache_length=cache_length,
+        head_size=head_size,
+        n_head=n_head,
+        dtype=dtype,
+    )
+    hooks = CellComputationAutogradHooks(
+        config=config,
+        batch_size=batch_size,
+    )
+    token_kwargs = dict(dtype=torch.int64, device=device)
+    replay_log = DefaultKVCacheReplayLog(
+        token_chunks=[torch.zeros(batch_size, cache_length, **token_kwargs)]
+        + [
+            torch.zeros(batch_size, chunk_size, **token_kwargs)
+            for _ in range(num_states)
+        ],
+        cache_length=cache_length,
+        max_prefill_length=cache_length,
+        grace_period=0,
+    )
+    hooks.initialize_cell(
+        eff_num_layers=1,
+        num_chunks=num_states + 1,
+        first_layer_idx=layer_idx,
+        first_chunk_idx=0,
+        cache_lengths=[cache_length],
+        replay_logs=[replay_log],
+    )
+
+    buffer_kwargs = dict(dtype=dtype, device=device)
+    states = {
+        1: torch.randn(
+            batch_size, n_query_groups, cache_length, head_size, **buffer_kwargs
+        )
+    }
+    annotations = {}
+    for c in range(2, num_states + 1):
+        prev = states[c - 1]
+        index = expand_index(
+            random_index(params, 0, cache_length, num=chunk_size, device=device),
+            head_size,
+        )
+        annot = NodeAnnotation(
+            kind=kind,
+            layer_idx=layer_idx,
+            chunk_idx=c - 1,
+            shape=tuple(prev.shape),
+            index=index,
+            delta=prev.gather(2, index),
+        )
+        annotations[c - 1] = annot
+        hooks.node_annotations.append_safe(annot)
+        new_values = torch.randn(
+            batch_size, n_query_groups, chunk_size, head_size, **buffer_kwargs
+        )
+        states[c] = prev.scatter(2, index, new_values)
+    hooks.node_annotations.set_final(
+        x=states[num_states],
+        layer_idx=layer_idx,
+        chunk_idx=num_states,
+        kind=kind,
+    )
+
+    # Register the chunk-2 annotation as a *matched* pack argument (i.e., an
+    # ID the autograd graph really refers to), so it must be served even
+    # after the buffer has been walked past it. The chunk-1 annotation is
+    # flushed as usual.
+    matched_id = 4242
+    hooks._packed_arg_for_id[matched_id] = PackArgumentAsAnnotation(
+        annot=annotations[2],
+        target_dtype=None,
+    )
+    hooks.node_annotations.nodes.remove(annotations[2])
+    hooks._match_annotations(flush_pack_args=True)
+    chunk1_id = next(
+        idd
+        for idd, e in hooks._packed_arg_for_id.items()
+        if isinstance(e, PackArgumentAsAnnotation) and e.annot.chunk_idx == 1
+    )
+
+    # Walk down to chunk 1. This applies the chunk-2 annotation early (as
+    # part of the chain walk) and must park its state
+    x1 = hooks.unpack_hook(chunk1_id)
+    torch.testing.assert_close(x1, states[1])
+    assert hooks.node_annotations.get_final(layer_idx, kind)[1] == 1
+
+    # Now autograd asks for chunk 2, whose state the buffer has moved past.
+    # Before the fix this raised `final chunk_idx = 1, must be >= 2`
+    x2 = hooks.unpack_hook(matched_id)
+    torch.testing.assert_close(x2, states[2])

--- a/test/kvcache/test_autograd_hooks.py
+++ b/test/kvcache/test_autograd_hooks.py
@@ -438,3 +438,166 @@ def test_unpack_out_of_order_request_after_walking_past(device):
     # Before the fix this raised `final chunk_idx = 1, must be >= 2`
     x2 = hooks.unpack_hook(matched_id)
     torch.testing.assert_close(x2, states[2])
+
+
+@pytest.mark.parametrize("device", available_backends())
+def test_parked_memory_is_bounded_and_released(device):
+    """
+    Memory guarantee for the chain walk (issue #148 review question).
+
+    States rebuilt ahead of their unpack request are parked so the late
+    request can be served. This test pins the two properties that bound the
+    cost:
+
+    1. Only states whose ID the autograd graph can actually request are
+       parked. IDs inserted by the flush purely to keep the chain complete
+       are never parked, so walking a long chain of them costs nothing.
+    2. A parked state is released as soon as its request arrives, so the
+       peak is set by how many requests are outstanding at once, not by the
+       chain length.
+
+    """
+    torch.random.manual_seed(31415927)
+    dtype = torch.float32
+    batch_size = 2
+    n_head = 4
+    n_query_groups = 2
+    head_size = 8
+    cache_length = 32
+    chunk_size = 8
+    num_states = 6  # long chain: gap of 5 from the final buffer
+    layer_idx = 0
+    kind = "scatter-value"
+
+    config = Config(
+        n_layer=1,
+        n_head=n_head,
+        n_query_groups=n_query_groups,
+        n_embd=n_head * head_size,
+        block_size=cache_length + num_states * chunk_size,
+        vocab_size=48,
+        rotary_percentage=1,
+    )
+    params = KVCacheParams(
+        max_batch_size=batch_size,
+        n_query_groups=n_query_groups,
+        cache_length=cache_length,
+        head_size=head_size,
+        n_head=n_head,
+        dtype=dtype,
+    )
+    hooks = CellComputationAutogradHooks(config=config, batch_size=batch_size)
+    token_kwargs = dict(dtype=torch.int64, device=device)
+    replay_log = DefaultKVCacheReplayLog(
+        token_chunks=[torch.zeros(batch_size, cache_length, **token_kwargs)]
+        + [
+            torch.zeros(batch_size, chunk_size, **token_kwargs)
+            for _ in range(num_states)
+        ],
+        cache_length=cache_length,
+        max_prefill_length=cache_length,
+        grace_period=0,
+    )
+    hooks.initialize_cell(
+        eff_num_layers=1,
+        num_chunks=num_states + 1,
+        first_layer_idx=layer_idx,
+        first_chunk_idx=0,
+        cache_lengths=[cache_length],
+        replay_logs=[replay_log],
+    )
+
+    buffer_kwargs = dict(dtype=dtype, device=device)
+    states = {
+        1: torch.randn(
+            batch_size, n_query_groups, cache_length, head_size, **buffer_kwargs
+        )
+    }
+    annotations = {}
+    for c in range(2, num_states + 1):
+        prev = states[c - 1]
+        index = expand_index(
+            random_index(params, 0, cache_length, num=chunk_size, device=device),
+            head_size,
+        )
+        annot = NodeAnnotation(
+            kind=kind,
+            layer_idx=layer_idx,
+            chunk_idx=c - 1,
+            shape=tuple(prev.shape),
+            index=index,
+            delta=prev.gather(2, index),
+        )
+        annotations[c - 1] = annot
+        hooks.node_annotations.append_safe(annot)
+        states[c] = prev.scatter(
+            2,
+            index,
+            torch.randn(
+                batch_size, n_query_groups, chunk_size, head_size, **buffer_kwargs
+            ),
+        )
+    hooks.node_annotations.set_final(
+        x=states[num_states],
+        layer_idx=layer_idx,
+        chunk_idx=num_states,
+        kind=kind,
+    )
+
+    # Case 1: the whole chain is flush-inserted (orphan) except the one being
+    # requested. Walking 5 links must park nothing at all.
+    matched_id = 9001
+    hooks._packed_arg_for_id[matched_id] = PackArgumentAsAnnotation(
+        annot=annotations[1], target_dtype=None
+    )
+    hooks.node_annotations.nodes.remove(annotations[1])
+    hooks._match_annotations(flush_pack_args=True)
+
+    x1 = hooks.unpack_hook(matched_id)
+    torch.testing.assert_close(x1, states[1])
+    log = hooks.annotation_usage_log()
+    assert log.parked_peak_count == 0, "orphan chain links must not be parked"
+    assert log.parked_peak_bytes == 0
+    assert not hooks._id_to_unpacked
+
+    # Case 2: every chain link is a real (matched) ID, so each is parked when
+    # applied early -- and released when its request arrives. The peak equals
+    # the number of outstanding requests, and memory returns to zero.
+    hooks.initialize_cell(
+        eff_num_layers=1,
+        num_chunks=num_states + 1,
+        first_layer_idx=layer_idx,
+        first_chunk_idx=0,
+        cache_lengths=[cache_length],
+        replay_logs=[replay_log],
+    )
+    ids = {}
+    for chunk_idx, annot in annotations.items():
+        ids[chunk_idx] = 9100 + chunk_idx
+        hooks._packed_arg_for_id[ids[chunk_idx]] = PackArgumentAsAnnotation(
+            annot=annot, target_dtype=None
+        )
+    hooks.node_annotations.set_final(
+        x=states[num_states],
+        layer_idx=layer_idx,
+        chunk_idx=num_states,
+        kind=kind,
+    )
+    hooks._match_annotations(flush_pack_args=True)
+
+    # Worst case: request the oldest state first, forcing the full walk
+    torch.testing.assert_close(hooks.unpack_hook(ids[1]), states[1])
+    log = hooks.annotation_usage_log()
+    one_buffer_bytes = states[1].numel() * states[1].element_size()
+    # num_states - 2 intermediate links get applied early and parked
+    assert log.parked_peak_count == num_states - 2
+    assert log.parked_peak_bytes == (num_states - 2) * one_buffer_bytes
+    # Bound claimed in review: at most (chunks_per_cell - 1) buffers per
+    # (layer, kind). Never a function of model size or step count.
+    assert log.parked_peak_count <= (num_states - 1)
+
+    # Serving the outstanding requests releases everything
+    for chunk_idx in range(2, num_states):
+        torch.testing.assert_close(hooks.unpack_hook(ids[chunk_idx]), states[chunk_idx])
+    assert not hooks._id_to_unpacked
+    assert hooks._parked_bytes == 0


### PR DESCRIPTION
## Summary

Fixes #148 (chunked backward fails when a generated region spans 3+ chunks).

`_unpack_from_annotation` assumed the final buffer for a `(layer, kind)` node is at most one chunk ahead of the annotation being unpacked (`final_idx in [chunk_idx, chunk_idx + 1]`). With long generated regions spanning 3+ backward chunks, autograd's backward for the intermediate chunks can be served without unpacking their `scatter-*`/`cat-*` annotations, so the gap grows beyond one chunk and backward dies with e.g. `ValueError: Annotation scatter-value (20,1): final chunk_idx = 3, must be in [1, 2]`.

## Changes

1. **`autograd_hooks.py`: walk the annotation chain across multi-chunk gaps.** All `scatter`/`cat` annotations are guaranteed to be present in `_packed_arg_for_id` after `_flush_remaining_pack_arguments` (they are inserted under fresh IDs even when unmatched, precisely to keep the reconstruction chain complete). `_unpack_from_annotation` now applies the intermediate annotations early, in descending chunk order, and parks each reconstructed intermediate state (as a copy, since the buffer is mutated in place) in `_id_to_unpacked`, so autograd can still fetch those IDs later. `_find_prior_annotation` is generalized to `_find_chain_annotation(annotation, chunk_idx)`; the legacy one-step ext-before-scatter behavior is preserved unchanged.

2. **`rl/grpo/loop.py`: pass `may_match_twice=may_match_twice_flex_attention_sdpa`.** With the new training replay cache, `ext-*` annotations legitimately match two pack arguments. The finetune path (`may_match_twice_factory`) and `test_gradient.py` both pass this predicate; the GRPO loop did not, so the second save of an ext buffer was left as an unmatched raw pack argument. Autograd's backward for that chunk can then be served from the raw copy without advancing the annotation chain — the likely trigger for the adjacency violation. This is the root-cause fix; change (1) makes the unpack robust even if the chain stalls for another reason.

## Why it only showed with long completions

With at most 2 buffer states per cell the gap can never exceed one chunk. QA-style runs (32-token completions) never hit it; long-generation runs (e.g. 2600-token completions, `chunk_size=1024`) hit it stochastically, dependent on per-row eos raggedness — consistent with the reports in #148.

## Testing

- New regression test `test_unpack_walks_multi_chunk_annotation_chain` (parametrized over chunk gaps 1, 2, 4): builds a ground-truth chain of buffer states linked by `scatter-value` annotations, sets the final buffer several chunks ahead, unpacks the earliest annotation, and verifies (a) correct reconstruction, (b) parked intermediate states are served when their IDs are unpacked later. The gap ≥ 2 cases fail with the exact #148 error before the fix and pass after.
- `test/kvcache/test_autograd_hooks.py`: 5 passed
- `test/kvcache/test_gradient.py`: 10 passed
- `test/kvcache/test_gradient_main.py` + `test/rl`: pass (CUDA-only cases skipped; verified on CPU, macOS)

Not verified: an end-to-end GPU reproduction of the original failing GRPO config (long-generation LongProc/longmath runs). We will requeue the previously crashed 32k jobs with this fix and report back on the issue.
