### PR TITLE
fix: move black, flake8 and hypothesis out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,16 @@ scripts.keys_values = "keys_values.__main__:main"
 
 dependencies = [
     "filelock",
-    "black>=26.3.1",
-    "flake8",
-    "hypothesis",
 ]
 
 [project.optional-dependencies]
 cuda = ["flashinfer-python"]
 trl = ["trl>=1.0.0"]
+dev = [
+    "black>=26.3.1",
+    "flake8",
+    "hypothesis",
+]
 
 [tool.setuptools.packages.find]
 include = [


### PR DESCRIPTION
Three of the four entries in `[project].dependencies` are development tools, so installing `keys-vals` drags a formatter, a linter and a property-testing library into every user environment.

**Why each one is a dev tool, not a runtime dependency:**

| Entry | Evidence |
|---|---|
| `black>=26.3.1` | never imported under `keys_values/`; the repo's own `black.sh` invokes it as `python -m black` |
| `flake8` | never imported under `keys_values/` |
| `hypothesis` | one import in the whole tree, in `test/attention/test_flashinfer_wrapper.py` |

`filelock` **stays** — it is imported at runtime by `keys_values/utils.py` and `keys_values/evaluation/tasks.py`.

**Solution.** The three tools move into a new `dev` extra under the existing `[project.optional-dependencies]` table:

```diff
 dependencies = [
     "filelock",
-    "black>=26.3.1",
-    "flake8",
-    "hypothesis",
 ]

 [project.optional-dependencies]
 cuda = ["flashinfer-python"]
 trl = ["trl>=1.0.0"]
+dev = [
+    "black>=26.3.1",
+    "flake8",
+    "hypothesis",
+]
```

**Design decision worth flagging:** this repo has no `[dependency-groups]` table, so the tools had to go somewhere new rather than simply being deleted — otherwise contributors lose the ability to format, lint and run the property tests. I added a `dev` extra to the table already in use for `cuda` and `trl`, rather than introducing PEP 735 `[dependency-groups]` as a second parallel mechanism. If you would rather have `[dependency-groups]`, say so and I will switch it.

**Verification**

Runtime resolution collapses to a single package:

```
$ uv pip compile pyproject.toml --python-version 3.11
before: 14 packages
after:   1 package     # filelock==3.32.4
```

Thirteen packages leave the runtime set: `black`, `flake8`, `hypothesis` plus `click`, `mccabe`, `mypy-extensions`, `packaging`, `pathspec`, `platformdirs`, `pycodestyle`, `pyflakes`, `pytokens`, `sortedcontainers`.

The tools are still installable for contributors:

```
$ uv pip compile --extra dev pyproject.toml --python-version 3.11
14 packages   # black==26.5.1, flake8==7.3.0, hypothesis==6.167.0
```

**What I could not verify, and a pre-existing issue behind it**

I could not run the test suite locally. Creating an environment fails on a resolution conflict that exists **independently of this change** — I confirmed it on both an unmodified checkout and this branch:

```
$ uv lock
  × No solution found when resolving dependencies
  ... the requested Python version (>=3.8) does not satisfy Python>=3.10
  hint: Consider limiting your project's supported Python versions
        using `requires-python`
```

`requires-python = ">=3.8"` no longer holds: `black>=26.3.1` requires Python >=3.10. Before this change that conflict sat on the *runtime* dependency path; after it, it sits on the `dev` extra path. Either way it is the same pre-existing problem and this PR neither introduces nor fixes it — narrowing `requires-python` (and refreshing the `Programming Language :: Python :: 3.8` classifier, which is also stale) is a separate call for you to make. Happy to send that as its own PR if you want it.

Because of that, the evidence above rests on dependency resolution rather than a green test run. The change touches no source code, and the `--extra dev` resolution confirms contributors keep every tool they had.

No issue number — I found this by reading the dependency list rather than from a report. CONTRIBUTING asks for an issue first on significant work; this is a four-line move, but tell me if you'd prefer an issue and I will open one.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
